### PR TITLE
use package power metrics

### DIFF
--- a/grafana/dashboard_gpu.json
+++ b/grafana/dashboard_gpu.json
@@ -154,7 +154,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "GPU current power usage",
+      "description": "GPU package power usage",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -210,13 +210,31 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "gpu_power_usage{gpu_uuid=\"$g_gpu_uuid\", hostname=\"$g_hostname\"}",
+          "expr": "gpu_average_package_power{gpu_uuid=\"$g_gpu_uuid\", hostname=\"$g_hostname\"}",
           "fullMetaSearch": false,
+          "hide": false,
           "includeNullMetadata": true,
           "instant": false,
           "legendFormat": "{{hostname}}[{{gpu_id}}]",
           "range": true,
           "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "gpu_package_power{gpu_uuid=\"$g_gpu_uuid\", hostname=\"$g_hostname\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{hostname}}[{{gpu_id}}]",
+          "range": true,
+          "refId": "B",
           "useBackend": false
         }
       ],
@@ -1788,7 +1806,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(gpu_id)",
+        "definition": "label_values({hostname=\"$g_hostname\"},gpu_id)",
         "hide": 0,
         "includeAll": false,
         "label": "GPU ID",
@@ -1797,7 +1815,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpu_id)",
+          "query": "label_values({hostname=\"$g_hostname\"},gpu_id)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/grafana/dashboard_job.json
+++ b/grafana/dashboard_job.json
@@ -946,7 +946,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Latest total power usage, in Watts",
+      "description": "Total package power usage, in Watts",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1000,11 +1000,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage{job_id!=\"\", job_id=\"$g_job_id\"})",
+          "expr": "sum(gpu_average_package_power{job_id!=\"\", job_id=\"$g_job_id\"})",
           "fullMetaSearch": false,
+          "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Power Usage",
+          "legendFormat": "Average Job Package Power Usage",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1016,15 +1017,69 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage{pod!=\"\", pod=\"$g_pod\"})",
+          "expr": "sum(gpu_package_power{job_id!=\"\", job_id=\"$g_job_id\"})",
           "fullMetaSearch": false,
-          "hide": false,
+          "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Power Usage",
+          "legendFormat": "Job Package Power Usage",
           "range": true,
           "refId": "B",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_average_package_power{pod!=\"\", pod=\"$g_pod\"})",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Average Pod Package Power Usage",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_package_power{pod!=\"\", pod=\"$g_pod\"})",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Pod Package Power Usage",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A+$B",
+          "hide": false,
+          "refId": "Total Job Package Power Usage",
+          "type": "math"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$C+$D",
+          "hide": false,
+          "refId": "Total Pod Package Power Usage",
+          "type": "math"
         }
       ],
       "title": "Total Power Usage",
@@ -2503,6 +2558,7 @@
   "templating": {
     "list": [
       {
+        "allValue": "+",
         "current": {},
         "datasource": {
           "type": "prometheus",
@@ -2527,6 +2583,7 @@
         "type": "query"
       },
       {
+        "allValue": "+",
         "current": {},
         "datasource": {
           "type": "prometheus",

--- a/grafana/dashboard_node.json
+++ b/grafana/dashboard_node.json
@@ -774,7 +774,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Total power usage, in Watts",
+      "description": "Total package power usage, in Watts",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -828,13 +828,41 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage{hostname=\"$g_hostname\"})",
+          "expr": "sum(gpu_average_package_power{hostname=\"$g_hostname\"})",
           "fullMetaSearch": false,
+          "hide": true,
           "includeNullMetadata": true,
-          "legendFormat": "Power Usage (W)",
+          "legendFormat": "Average Package Power Usage",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_package_power{hostname=\"$g_hostname\"})",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Package Power Usage",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A+$B",
+          "hide": false,
+          "refId": "Total Package Power Usage",
+          "type": "math"
         }
       ],
       "title": "Total Power Usage",

--- a/grafana/dashboard_overview.json
+++ b/grafana/dashboard_overview.json
@@ -307,14 +307,42 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage)",
+          "expr": "sum(gpu_average_package_power)",
           "fullMetaSearch": false,
+          "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Power Usage (W)",
+          "legendFormat": "Average Package Power (W)",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_package_power)",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Current Package Power (W)",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A+$B",
+          "hide": false,
+          "refId": "Total Package Power Usage",
+          "type": "math"
         }
       ],
       "title": "Total Power Usage",


### PR DESCRIPTION
in power usage tile, on all dashboards, switch from using gpu_power_usage metric to gpu_average_package_power and gpu_package_power

gpu-operator PR: https://github.com/ROCm/gpu-operator/pull/43
pensando repo PR: https://github.com/pensando/device-metrics-exporter/pull/205