### PR TITLE
add default config map with all labels if not supplied by user for helm installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/bin
 pkg/slurm/sim/slurm-sim
 .venv
 _build
+helm-charts/config.json

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 DOCKER_REGISTRY ?= docker.io/rocm
 
 # Build Container environment
-DOCKER_BUILDER_TAG ?= v1.0
+DOCKER_BUILDER_TAG ?= v1.1
 BUILD_BASE_IMAGE ?= ubuntu:22.04
 BUILD_CONTAINER ?= $(DOCKER_REGISTRY)/device-metrics-exporter-build:$(DOCKER_BUILDER_TAG)
 
@@ -44,6 +44,7 @@ TOP_DIR := $(PWD)
 GEN_DIR := $(TOP_DIR)/pkg/amdgpu/
 MOCK_DIR := ${TOP_DIR}/pkg/amdgpu/mock_gen
 HELM_CHARTS_DIR := $(TOP_DIR)/helm-charts
+CONFIG_DIR := $(TOP_DIR)/example/
 GOINSECURE='github.com, google.golang.org, golang.org'
 GOFLAGS ='-buildvcs=false'
 BUILD_DATE ?= $(shell date   +%Y-%m-%dT%H:%M:%S%z)
@@ -322,6 +323,7 @@ k8s-e2e:
 
 .PHONY: helm-lint
 helm-lint:
+	jq 'del(.ServerPort, .GPUConfig.Fields, .GPUConfig.CustomLabels)' $(CONFIG_DIR)/config.json > $(HELM_CHARTS_DIR)/config.json
 	cd $(HELM_CHARTS_DIR); helm lint
 
 .PHONY: helm-build

--- a/helm-charts/templates/configmap.yaml
+++ b/helm-charts/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+data:
+  config.json: |-
+{{ .Files.Get "config.json" | indent 4}}

--- a/helm-charts/templates/daemonsets.yaml
+++ b/helm-charts/templates/daemonsets.yaml
@@ -69,10 +69,8 @@ spec:
             name: exporter-health-grpc-volume
           - mountPath: /var/run/exporter
             name: exporter-slurm-job
-          {{- if .Values.configMap }}
           - name: metrics-config-volume
             mountPath: /etc/metrics/
-          {{- end }}
           workingDir: /root
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -99,8 +97,11 @@ spec:
           path: /var/run/exporter
           type: DirectoryOrCreate
         name: exporter-slurm-job
-      {{- if .Values.configMap }}
       - name: metrics-config-volume
         configMap:
+      {{- if .Values.configMap }}
           name: {{ .Values.configMap }}
+      {{ else }}
+          name: {{ .Release.Name }}-configmap
       {{- end}}
+

--- a/tools/base-image/Dockerfile
+++ b/tools/base-image/Dockerfile
@@ -12,7 +12,7 @@ RUN rm -rf /usr/local/go
 
 RUN apt-get update && apt-get install -y wget protobuf-compiler \
     curl locales ca-certificates build-essential git vim \
-    net-tools sudo cmake build-essential && \
+    net-tools sudo cmake build-essential jq && \
     install -m 0755 -d /etc/apt/keyrings && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
 ```
helm install test-config-metrics -n kube-amd-gpu ./device-metrics-exporter-charts-v1.2.0.tgz
NAME: test-config-metrics
LAST DEPLOYED: Mon Mar 24 21:59:45 2025
NAMESPACE: kube-amd-gpu
STATUS: deployed
REVISION: 1
TEST SUITE: None
ubuntu@cl3-node3-gpu-operator:~/praveen/helmcharts$ kubectl get configmap -n kube-amd-gpu test-config-metrics-configmap
NAMESPACE         NAME                                                   DATA   AGE
kube-amd-gpu      test-config-metrics-configmap                          1      8s
```