### PR TITLE
Add numactl numactl-libs to exporter Dockerfile

### DIFF
--- a/docker/Dockerfile.azure.linux3.exporter-release
+++ b/docker/Dockerfile.azure.linux3.exporter-release
@@ -24,7 +24,7 @@ RUN tdnf clean all && tdnf install -y ca-certificates && \
     echo "priority=50" >> /etc/yum.repos.d/rocm.repo && \
     echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo && \
     echo "gpgkey=${AMDGPU_REPO_URL}/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo && \
-    tdnf install -y sudo findutils procps elfutils-libelf cmake kmod file libcap-devel amd-smi-lib libdrm-amdgpu vim net-tools && \
+    tdnf install -y sudo findutils procps elfutils-libelf cmake kmod file libcap-devel amd-smi-lib libdrm-amdgpu vim net-tools numactl numactl-libs && \
     rm -rf /var/cache/yum && rm -rf /var/cache/dnf && tdnf clean all
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/amd/bin/:/opt/rocm/bin/

--- a/docker/Dockerfile.exporter-release
+++ b/docker/Dockerfile.exporter-release
@@ -25,7 +25,7 @@ RUN microdnf clean all && \
     echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo && \
     echo "gpgkey=${AMDGPU_REPO_URL}/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo && \
     microdnf update -y && \
-    microdnf install -y sudo findutils procps elfutils-libelf cmake kmod file libcap-devel amd-smi-lib libdrm-amdgpu vim net-tools && \
+    microdnf install -y sudo findutils procps elfutils-libelf cmake kmod file libcap-devel amd-smi-lib libdrm-amdgpu vim net-tools numactl numactl-libs && \
     rm -rf /var/cache/yum && rm -rf /var/cache/dnf && microdnf clean all
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/amd/bin/:/opt/rocm/bin/


### PR DESCRIPTION
- numactl and numactl-libs are necessary to run exporter in Singularity environment.