### PR TITLE
update timestamp in log export filename

### DIFF
--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -745,7 +745,7 @@ func (tr *TestRunner) saveAndExportHandlerLogs(handler types.TestHandlerInterfac
 			filesToExport = append(filesToExport, resultsJson)
 		}
 		now := time.Now().UTC()
-		timestamp := now.Format("2006-01-02T15_04_05Z")
+		timestamp := now.Format("2006-01-02T15-04-05.000000Z")
 		if res.Stdout != "" {
 			stdoutFilePath := GetLogFilePath(tr.logDir, timestamp, tr.testTrigger, recipe, "stdout")
 			SaveTestResultToGz(res.Stdout, stdoutFilePath)


### PR DESCRIPTION
current log export file name does not have microseconds precision. when multiple runs/iterations are done in quick succession, the log export file is getting overwritten with latest one(with seconds in file name). we need to have microseconds to avoid race condition