### PR TITLE
show metrics prefix setting (#565)

### DIFF
--- a/grafana/dashboard_gpu.json
+++ b/grafana/dashboard_gpu.json
@@ -2019,7 +2019,6 @@
           "value": ""
         },
         "description": "string to prefix names of metrics queries (e.g. gpu_gfx_activity -> amd_gpu_gfx_activity)",
-        "hide": 2,
         "label": "Metrics Prefix",
         "name": "g_metrics_prefix",
         "options": [

--- a/grafana/dashboard_job.json
+++ b/grafana/dashboard_job.json
@@ -2725,7 +2725,6 @@
           "value": ""
         },
         "description": "string to prefix names of metrics queries (e.g. gpu_gfx_activity -> amd_gpu_gfx_activity)",
-        "hide": 2,
         "label": "Metrics Prefix",
         "name": "g_metrics_prefix",
         "options": [

--- a/grafana/dashboard_node.json
+++ b/grafana/dashboard_node.json
@@ -2363,7 +2363,6 @@
           "value": ""
         },
         "description": "string to prefix names of metrics queries (e.g. gpu_gfx_activity -> amd_gpu_gfx_activity)",
-        "hide": 2,
         "label": "Metrics Prefix",
         "name": "g_metrics_prefix",
         "options": [

--- a/grafana/dashboard_overview.json
+++ b/grafana/dashboard_overview.json
@@ -2521,7 +2521,6 @@
           "value": ""
         },
         "description": "string to prefix names of metrics queries (e.g. gpu_gfx_activity -> amd_gpu_gfx_activity)",
-        "hide": 2,
         "label": "Metrics Prefix",
         "name": "g_metrics_prefix",
         "options": [


### PR DESCRIPTION
cherry-pick https://github.com/pensando/device-metrics-exporter/pull/565

show metrics prefix setting on top of dashboard. this allows user to toggle metrics prefix value without having to go into settings page when switching between clusters that may have different prefixes or none at all.

<img width="606" alt="Screenshot 2025-06-13 at 12 40 13 AM" src="https://github.com/user-attachments/assets/5831ff1b-6204-4a9a-8596-d57a4e82bdf0" />
