### PR TITLE
[CP 676][Fix] fix gpu model specific recipe loading with non-global test config

### DIFF
--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -204,29 +204,30 @@ func (tr *TestRunner) validateTestTrigger() {
 		if params, ok := categoryConfig.TestLocationTrigger[tr.hostName].TestParameters[tr.testTrigger]; !ok {
 			fmt.Printf("failed to get test trigger %+v under category %+v config: %+v\n", tr.testTrigger, categoryConfig, categoryConfig.TestLocationTrigger[tr.hostName])
 			os.Exit(1)
-		} else if len(params.TestCases) == 0 {
+		} else if len(params.TestCases) == 0 || params.TestCases[0] == nil {
 			fmt.Printf("failed to get test case under category %+v trigger %+v config: %+v\n", categoryConfig, tr.testTrigger, categoryConfig.TestLocationTrigger[tr.hostName])
 			os.Exit(1)
 		}
 		tr.testLocation = tr.hostName
-		return
+	} else {
+		// if host specific config was not found
+		// validate global config's trigger
+		if categoryConfig.TestLocationTrigger[globals.GlobalTestTriggerKeyword].TestParameters == nil {
+			fmt.Printf("failed to get any test trigger under category %+v global config: %+v\n", categoryConfig, categoryConfig.TestLocationTrigger[tr.hostName])
+			os.Exit(1)
+		}
+		if params, ok := categoryConfig.TestLocationTrigger[globals.GlobalTestTriggerKeyword].TestParameters[tr.testTrigger]; !ok {
+			fmt.Printf("failed to get test trigger %+v under category %+v global config: %+v\n", tr.testTrigger, categoryConfig, categoryConfig.TestLocationTrigger[tr.hostName])
+			os.Exit(1)
+		} else if len(params.TestCases) == 0 || params.TestCases[0] == nil {
+			fmt.Printf("failed to get test case under category %+v trigger %+v global config: %+v\n", categoryConfig, tr.testTrigger, categoryConfig.TestLocationTrigger[tr.hostName])
+			os.Exit(1)
+		}
+		tr.testLocation = globals.GlobalTestTriggerKeyword
 	}
-	// if host specific config was not found
-	// validate global config's trigger
-	if categoryConfig.TestLocationTrigger[globals.GlobalTestTriggerKeyword].TestParameters == nil {
-		fmt.Printf("failed to get any test trigger under category %+v global config: %+v\n", categoryConfig, categoryConfig.TestLocationTrigger[tr.hostName])
-		os.Exit(1)
-	}
-	if params, ok := categoryConfig.TestLocationTrigger[globals.GlobalTestTriggerKeyword].TestParameters[tr.testTrigger]; !ok {
-		fmt.Printf("failed to get test trigger %+v under category %+v global config: %+v\n", tr.testTrigger, categoryConfig, categoryConfig.TestLocationTrigger[tr.hostName])
-		os.Exit(1)
-	} else if len(params.TestCases) == 0 || params.TestCases[0] == nil {
-		fmt.Printf("failed to get test case under category %+v trigger %+v global config: %+v\n", categoryConfig, tr.testTrigger, categoryConfig.TestLocationTrigger[tr.hostName])
-		os.Exit(1)
-	}
-	tr.testLocation = globals.GlobalTestTriggerKeyword
 	logger.Log.Printf("applied test config for %+v", tr.testLocation)
 
+	// 4. validate specific GPU model's test recipe
 	testParams := tr.getTestParameters(false)
 	gpuModelSubDir, err := getGPUModelTestRecipeDir(tr.rocmSMIPath)
 	if err != nil {


### PR DESCRIPTION
1. test runner will load user provided config map and read config.json inside it, users could provide a global test config, or per node specific test config.
2. after that test runner would read the test recipes folder to check:

* whether detected GPU model's test recipe subfolder exist or not
* whether given test recipe file exist in the GPU model's subfolder or not

4. There is a bug that when users define per node specific test config, the test runner won't detect the GPU model and detect test recipe files in corresponding GPU subfolder.

This PR is fixing the issue, making sure the test runner will detect test recipe file in corresponding GPU model subfolder when given per node specific test config.