### PR TITLE
security: fix CVE-2025-47907 by updating Go to 1.24.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ mod:
 	@touch ${TOP_DIR}/libamdsmi/go.mod
 	@echo "setting up go mod packages"
 	@go mod tidy
-	@go mod edit -go=1.24.4
+	@go mod edit -go=1.24.6
 	#CVE-2024-24790 - amd-metrics-exporter
 	@go mod edit -replace golang.org/x/net@v0.29.0=golang.org/x/net@v0.36.0
 	#CVE-2025-30204 - amd-test-runner

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ROCm/device-metrics-exporter
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
## Motivation

This PR addresses a HIGH severity security vulnerability (CVE-2025-47907) identified by the security team in our Go binaries. The vulnerability affects the Go standard library v1.24.4 and involves improper handling of query cancellation in database drivers, which could lead to unexpected behavior when contexts are cancelled.

## Technical Details

**Security Fix: CVE-2025-47907**
- Updated Go version requirement from 1.24.4 to 1.24.6 in `go.mod`
- Updated `Makefile` mod target to use Go 1.24.6 (line 334)
- Rebuilt affected binaries: `metricsclient` and `amd-metrics-exporter`

**Files Modified:**
- `go.mod` - Updated Go version requirement
- `Makefile` - Updated hardcoded Go version in mod target

**Vulnerability Details:**
- **CVE**: CVE-2025-47907
- **Severity**: HIGH  
- **Component**: Go standard library
- **Fix Version**: Go 1.23.12, 1.24.6+
- **Reference**: https://avd.aquasec.com/nvd/cve-2025-47907

## Test Plan

1. **Dependency Update Verification**: Ran `go mod tidy` to ensure dependency consistency
2. **Build Verification**: Successfully built both affected binaries:
   - `make amdexporter` - Built `bin/amd-metrics-exporter`
   - `make metricsclient` - Built `bin/metricsclient`
3. **Version Verification**: Confirmed binaries use patched Go version:
   ```bash
   go version -m bin/metricsclient
   go version -m bin/amd-metrics-exporter
   ```

## Test Result

✅ **All tests passed successfully:**
- Dependencies updated without conflicts
- Both binaries built successfully with Go 1.24.6
- Binary verification confirms security fix is applied:
  ```
  bin/metricsclient: go1.24.6
  bin/amd-metrics-exporter: go1.24.6
  ```
- No breaking changes introduced
- CVE-2025-47907 vulnerability resolved

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.