### PR TITLE
add techsupport collection script help for different deployments (#799)

### DIFF
--- a/docs/configuration/troubleshooting.md
+++ b/docs/configuration/troubleshooting.md
@@ -2,6 +2,23 @@
 
 This topic provides an overview of troubleshooting options for Device Metrics Exporter.
 
+## Using Techsupport-dump Tool
+
+The [techsupport-dump script](https://github.com/ROCm/device-metrics-exporter/blob/main/tools/techsupport_dump.sh) can be used to collect system state and logs for debugging:
+
+```bash
+# ./techsupport_dump.sh [-w] [-o yaml/json] [-k kubeconfig] [-r helm-release-name] <node-name/all>
+```
+
+Options:
+
+- `-w`: wide option
+- `-o yaml/json`: output format (default: json)
+- `-k kubeconfig`: path to kubeconfig (default: ~/.kube/config)
+- `-r  helm-release-name`: helm release name
+
+Please file an issue with collected techsupport bundle on our [GitHub Issues](https://github.com/ROCm/device-metrics-exporter/issues) page
+
 ## Logs
 You can view the container logs by executing the following command:
 
@@ -22,7 +39,25 @@ kubectl logs -n <namespace> <exporter-container-on-node>
 sudo journalctl -xu amd-metrics-exporter
 ```
 
-logs are collected in file `/var/run/exporter.log`
+logs are collected in directory `/var/log/` files 
+- exporter.log
+- gpu-agent.log
+- gpu-agent-api.log
+- gpu-agent-err.log
+
+#### Debian Techsupport Collection Command
+
+```bash
+sudo journalctl -xu amd-metrics-exporter > amd-metrics-exporter.log
+sudo journalctl -xu gpuagent > amd-gpu-agent.log
+
+sudo tar -czf amd-metrics-exporter-techsupport-$(date +%Y%m%d-%H%M%S).tar.gz \
+   amd-metrics-exporter.log \
+   amd-gpu-agent.log \
+   /var/log/exporter.log \
+   /var/log/gpu-agent*.log
+
+```
 
 ## Common Issues
 


### PR DESCRIPTION
(cherry picked from commit ca95a45b24c5d5666483313e339a32a0f2846fe6)

## Motivation

Enhance Techsupport collection documentation for reporting issues.


## Test Result

Debian collected Script from the docs instructions.

```bash

prshanmug@mi325x8-110:~/operator$ tar tvf amd-metrics-exporter-techsupport-20250820-221919.tar.gz
-rw-rw-r-- prshanmug/prshanmug 109786609 2025-08-20 22:18 amd-metrics-exporter.log
-rw-rw-r-- prshanmug/prshanmug  24375789 2025-08-20 22:18 amd-gpu-agent.log
-rw-r--r-- root/root               10574 2025-08-14 17:21 var/log/exporter.log
-rw-r--r-- root/root                   0 2025-08-14 16:35 var/log/gpu-agent-api.log
-rw-r--r-- root/root              209912 2025-08-14 17:21 var/log/gpu-agent-err.log
-rw-r--r-- root/root              241487 2025-08-14 17:21 var/log/gpu-agent.log

```



