### PR TITLE
[Fix] GPUOP-436 fix the logging of test recipe name

### DIFF
--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -894,7 +894,7 @@ func (tr *TestRunner) testGPU(trigger string, ids []string, isRerun bool) {
 
 	select {
 	case <-time.After(time.Duration(Deref(parameters.TestCases[0].TimeoutSeconds)) * time.Second * time.Duration(Deref(parameters.TestCases[0].Iterations))):
-		logger.Log.Printf("Trigger: %v Test: %v GPU Indexes: %v timeout", trigger, parameters.TestCases[0].Recipe, validIDs)
+		logger.Log.Printf("Trigger: %v Test: %v GPU Indexes: %v timeout", trigger, Deref(parameters.TestCases[0].Recipe), validIDs)
 		result := handler.Result()
 		result = AppendTimedoutTestSummary(result, validIDs)
 		handler.StopTest()

--- a/pkg/testrunner/utils.go
+++ b/pkg/testrunner/utils.go
@@ -370,7 +370,7 @@ func removeIDsWithExistingTest(trigger, statusDBPath string, ids []string, param
 	for _, id := range ids {
 		if testStatus, ok := statusObj.TestStatus[id]; ok && !isRerun {
 			logger.Log.Printf("trigger %+v is trying to run test %+v on device %+v but found existing %v test, skip for now",
-				trigger, parameters.TestCases[0].Recipe, id, testStatus)
+				trigger, Deref(parameters.TestCases[0].Recipe), id, testStatus)
 		} else {
 			validIDs = append(validIDs, id)
 		}


### PR DESCRIPTION
## Motivation

Fix logging of test recipe name for test runner, otherwise the pointer address will show up in the pod logs instead of the recipe name.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
