### PR TITLE
[Fix] Update test runner statusDB after failed manual run

### DIFF
--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -1064,6 +1064,7 @@ func (tr *TestRunner) exitOnFailure(recipe string, validIDs []string) {
 		testrunnerGen.TestTrigger_PRE_START_JOB_CHECK.String():
 		if len(validIDs) > 0 {
 			tr.RemoveTestRunningLabel(recipe, validIDs)
+			tr.updateStatusDBAfterTestRun(validIDs, types.TestCompleted.String())
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Motivation

When the test runner failed during the manual / pre-start job test run, it should remove the test running status from the temporary test runner db file, so that it won't show the test is still running.

## Technical Details

Amend a function call to clean the status when the manual / pre-start job test failed.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
