### PR TITLE
fix : remove deletion of 0 logic to avoid automation causing issues n book keeping

### DIFF
--- a/pkg/amdgpu/gpuagent/gpuagent_health.go
+++ b/pkg/amdgpu/gpuagent/gpuagent_health.go
@@ -251,16 +251,6 @@ func (ga *GPUAgentClient) SetError(gpuid string, fields []string, values []uint3
 		ga.mockEccField[gpuid] = make(map[string]uint32)
 	}
 	for i, field := range fields {
-		if values[i] == 0 {
-			// nolint : gosimple
-			if _, ok := ga.mockEccField[gpuid][field]; ok {
-				delete(ga.mockEccField[gpuid], field)
-			}
-			if len(ga.mockEccField[gpuid]) == 0 {
-				delete(ga.mockEccField, gpuid)
-			}
-			continue
-		}
 		ga.mockEccField[gpuid][field] = values[i]
 	}
 	return nil


### PR DESCRIPTION
(cherry picked from commit 77492e78b512df1f8d3e3ccd43f4e1dd7a55464f)

GPUOP-462: metrics exporter crashes at amdgpu/gpuagent.(*GPUAgentClient).SetError while injecting errors
 fix : remove deletion of 0 logic to avoid automation injecting 0 on first request

unit test:

```bash
[root@gpu-operator-metrics-exporter-5gz96 ~]# metricsclient -ecc-file-path ./ecc.json
{"ID":"0","Fields":["GPU_ECC_UNCORRECT_JPEG","GPU_ECC_UNCORRECT_SEM"]}
ID         UUID                                     Health     Associated Workload
------------------------------------------------
0          9fff74b9-0000-1000-8044-4a2fb30adeb0     healthy    [pod : pytorch-vgg256-cifar10, namespace : default, container: pytorch-vgg256-cifar10]
1          b7ff74b9-0000-1000-80d1-81671a192e45     healthy    [pod : pytorch-resnet50-cifar100, namespace : default, container: pytorch-resnet50-cifar100]
2          8cff74b9-0000-1000-802c-c938055be37b     healthy    []
3          b6ff74b9-0000-1000-804b-b933ce354f93     healthy    []
4          86ff74b9-0000-1000-8011-bf652f8b2b89     healthy    []
5          93ff74b9-0000-1000-8039-eaff7921b68e     healthy    []
6          72ff74b9-0000-1000-8094-e35bd3b6cc56     healthy    []
7          27ff74b9-0000-1000-80f7-cf00e06ab2b5     healthy    []
------------------------------------------------
[root@gpu-operator-metrics-exporter-5gz96 ~]# metricsclient
ID         UUID                                     Health     Associated Workload
------------------------------------------------
0          9fff74b9-0000-1000-8044-4a2fb30adeb0     unhealthy  [pod : pytorch-vgg256-cifar10, namespace : default, container: pytorch-vgg256-cifar10]
1          b7ff74b9-0000-1000-80d1-81671a192e45     healthy    [pod : pytorch-resnet50-cifar100, namespace : default, container: pytorch-resnet50-cifar100]
2          8cff74b9-0000-1000-802c-c938055be37b     healthy    []
3          b6ff74b9-0000-1000-804b-b933ce354f93     healthy    []
4          86ff74b9-0000-1000-8011-bf652f8b2b89     healthy    []
5          93ff74b9-0000-1000-8039-eaff7921b68e     healthy    []
6          72ff74b9-0000-1000-8094-e35bd3b6cc56     healthy    []
7          27ff74b9-0000-1000-80f7-cf00e06ab2b5     healthy    []
------------------------------------------------
[root@gpu-operator-metrics-exporter-5gz96 ~]#

```