### PR TITLE
Add podAnnotations and service annotations support to Helm chart

### DIFF
--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -30,6 +30,8 @@ Kubernetes: `>= 1.29.0-0`
 | kubelet.podResourceAPISocketPath | string | `"/var/lib/kubelet/pod-resources"` | host path for kubelet pod-resources directory (optional)    - vanilla k8s kubelet path: /var/lib/kubelet/pod-resources    - micro k8s kubelet path: /var/snap/microk8s/common/var/lib/kubelet/pod-resources/    - default to /var/lib/kubelet/pod-resources |
 | nodeSelector | object | `{}` | Add node selector for the daemonset of metrics exporter |
 | platform | string | `"k8s"` | Specify the platform to deploy the metrics exporter, k8s or openshift |
+| podAnnotations | object | `{}` | Add annotations to the pods |
+| service.annotations | object | `{}` | Add annotations to the service |
 | service.ClusterIP.port | int | `5000` | set port for ClusterIP type service |
 | service.NodePort.nodePort | int | `32500` | set nodePort for NodePort type service   |
 | service.NodePort.port | int | `5000` | set port for NodePort type service    |

--- a/helm-charts/templates/daemonsets.yaml
+++ b/helm-charts/templates/daemonsets.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-amdgpu-metrics-exporter
         app.kubernetes.io/name: metrics-exporter
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: amdgpu-metrics-exporter
       {{- if .Values.nodeSelector }}

--- a/helm-charts/templates/metrics-exporter-service.yaml
+++ b/helm-charts/templates/metrics-exporter-service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Release.Name }}-amd-metrics-exporter-svc
   labels:
     app: {{ .Release.Name }}-amdgpu-metrics-exporter
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: {{ .Release.Name }}-amdgpu-metrics-exporter

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -7,6 +7,9 @@ nodeSelector: {}
 # -- Add tolerations for deploying metrics exporter on tainted nodes
 tolerations: []
 
+# -- Add annotations to the pods
+podAnnotations: {}
+
 # -- kubelet configuration
 kubelet:
   # -- host path for kubelet pod-resources directory (optional)
@@ -30,6 +33,8 @@ image:
 service:
   # -- metrics exporter service type, could be ClusterIP or NodePort
   type: ClusterIP
+  # -- Add annotations to the service
+  annotations: {}
   ClusterIP:
     # -- set port for ClusterIP type service
     port: 5000


### PR DESCRIPTION
## Motivation

Add support for custom annotations on pods and services in the Helm chart to enable better integration with observability platforms, service meshes, and cloud provider services. This allows users to configure metrics collection (Prometheus, Datadog), load balancer settings, external-dns, and other annotation-based integrations without modifying the chart templates.

## Technical Details

**Added `podAnnotations` support:**
- Added `podAnnotations: {}` parameter in `values.yaml`
- Updated `templates/daemonsets.yaml` to apply annotations to the DaemonSet pod template metadata

**Added `service.annotations` support:**
- Added `service.annotations: {}` parameter in `values.yaml`
- Updated `templates/metrics-exporter-service.yaml` to apply annotations to the Service metadata

Both parameters accept a dictionary of key-value pairs that will be rendered using `toYaml` with proper indentation.

## Test Plan

- Verify Helm chart renders correctly with default empty annotations
- Test with custom pod annotations (e.g., Prometheus scraping directives)
- Test with custom service annotations (e.g., load balancer settings)
- Validate the generated YAML has correct indentation and structure

## Test Result

Helm chart templates render successfully with both empty and populated annotation values. The annotations are properly applied to the pod template and service metadata sections.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
