### PR TITLE
[Feature] Add pod UID and framework name in test runner event (#909)

### DIFF
--- a/example/testrunner/manual_test_job.yaml
+++ b/example/testrunner/manual_test_job.yaml
@@ -111,6 +111,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/example/testrunner/pre_start_job_check.yaml
+++ b/example/testrunner/pre_start_job_check.yaml
@@ -120,6 +120,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:

--- a/example/testrunner/schedule_test_cronjob.yaml
+++ b/example/testrunner/schedule_test_cronjob.yaml
@@ -113,6 +113,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/testrunner/utils.go
+++ b/pkg/testrunner/utils.go
@@ -418,12 +418,13 @@ func GetTestRunningLabelKeyValue(category, recipe string, indexes []string) ([]s
 	return keys, "running"
 }
 
-func GetEventLabels(category, trigger, recipe, hostName string, gpuIndexes, kfdIDs []string) map[string]string {
+func GetEventLabels(category, trigger, framework, recipe, hostName string, gpuIndexes, kfdIDs []string) map[string]string {
 	labels := map[string]string{
-		"testrunner.amd.com/category": strings.ToLower(category),
-		"testrunner.amd.com/trigger":  strings.ToLower(trigger),
-		"testrunner.amd.com/recipe":   recipe,
-		"testrunner.amd.com/hostname": hostName,
+		"testrunner.amd.com/category":  strings.ToLower(category),
+		"testrunner.amd.com/trigger":   strings.ToLower(trigger),
+		"testrunner.amd.com/recipe":    recipe,
+		"testrunner.amd.com/hostname":  hostName,
+		"testrunner.amd.com/framework": framework,
 	}
 	// find the commonly shorter length of 2 list: gpuIndexes and kfdIDs
 	// make sure the loop is not out of boundary


### PR DESCRIPTION
## Motivation

Add more information to test runner generated test result events:
* pod UID
* framework name

Those fields are required by OpenShift web console to properly showcase the detailed test run information

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
