### PR TITLE
documentation fixes and docker run update instructions (#977)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,6 @@
 
 AMD Device Metrics Exporter enables real-time collection of telemetry data in Prometheus format from AMD GPUs in HPC and AI environments. It provides comprehensive metrics including temperature, utilization, memory usage, power consumption, and more.
 
-## Quick Start
-
-The Metrics Exporter container is available on Docker Hub:
-
-```bash
-docker run -d \
-  --device=/dev/dri \
-  --device=/dev/kfd \
-  -p 5000:5000 \
-  --name device-metrics-exporter \
-  rocm/device-metrics-exporter:v1.5.0
-```
-
 ## Features
 
 - Prometheus-compatible metrics endpoint
@@ -29,20 +16,6 @@ docker run -d \
 - Slurm integration support
 - Configurable service ports
 - Container-based deployment
-
-
-## Requirements
-
-- Ubuntu 22.04, 24.04
-- Docker (or compatible container runtime)
-
-| Rocm Version | Driver Version | Exporter Image Version | Platform     |
-|--------------|----------------|------------------------|--------------|
-| 6.2.x        | 6.8.5          | v1.0.0                 | MI2xx, MI3xx |
-| 6.3.x        | 6.10.5         | v1.1.0, v1.2.0         | MI2xx, MI3xx |
-| 6.4.x        | 6.12.12        | v1.3.0                 | MI3xx        |
-| 6.4.x        | 6.12.12        | v1.3.0.1               | MI2xx, MI3xx |
-
 
 ## Documentation
 

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -6,10 +6,13 @@ To use a custom configuration with the AMD Device Metrics Exporter container:
 2. Save `config.json` in the `config/` folder
 3. Mount the `config/` folder when starting the container:
 
+**_NOTE:_** : `/sys` mount is required for inband-ras
+
 ```bash
 docker run -d \
   --device=/dev/dri \
   --device=/dev/kfd \
+  -v /sys:/sys:ro \
   -p 5000:5000 \
   -v ./config:/etc/metrics \
   --name device-metrics-exporter \

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -12,12 +12,15 @@ This page explains how to install AMD Device Metrics Exporter using Docker.
 
 The Device Metrics Exporter container is hosted on Docker Hub at [rocm/device-metrics-exporter](https://hub.docker.com/r/rocm/device-metrics-exporter).
 
+**_NOTE:_** : `/sys` mount is required for inband-ras
+
 - Start the container:
 
 ```bash
 docker run -d \
   --device=/dev/dri \
   --device=/dev/kfd \
+  -v /sys:/sys:ro \
   -p 5000:5000 \
   --name device-metrics-exporter \
   rocm/device-metrics-exporter:v1.5.0


### PR DESCRIPTION
* Remove quick start and requirements in root README.md, this is maintained in different docs/index.md

* Add /sys volume mount for inband-ras to docker run instructions in installation and configuration docs

(cherry picked from commit bbd9cb332641edbfa2de9393e9577c450369077f)

pensando/device-metrics-exporter#977