### PR TITLE
[Build] update helm lint command to match with helm v3/v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ ifeq ($(NIC_BUILD),1)
 else
 	jq 'del(.ServerPort, .GPUConfig.ExtraPodLabels)' $(CONFIG_DIR)/config-gpu.json > $(HELM_CHARTS_DIR)/config.json
 endif
-	cd $(HELM_CHARTS_DIR); helm lint
+	cd $(HELM_CHARTS_DIR); helm lint .
 
 # cicd target to build helm chart - requires PROJECT_VERSION, EXPORTER_IMAGE_TAG to be set
 .PHONY: helm


### PR DESCRIPTION
## Motivation

The latest helm v4 no longer support `helm lint` without a given path, we have to add `.` to make it apply to the helm chart in the current directory.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
