### PR TITLE
exporter was crashing on boot up

### DIFF
--- a/pkg/exporter/svc/svc_handler.go
+++ b/pkg/exporter/svc/svc_handler.go
@@ -83,6 +83,9 @@ func InitSvcs(mh *metricsutil.MetricsHandler, opts ...SvcHandlerOption) *SvcHand
 	for _, o := range opts {
 		o(svcHandler)
 	}
+
+	svcHandler.gpuHealthSvc = gpumetricsserver.NewMetricsServer(svcHandler.enableDebugAPI)
+	svcHandler.nicHealthSvc = nicmetricsserver.NewMetricsServer(svcHandler.enableDebugAPI)
 	return svcHandler
 }
 


### PR DESCRIPTION
root cause : one of the variables was not initalized properly
fix : variable is initialized

UT validation

```bash
[root@default-metrics-exporter-w9bhz ~]# server --version
Info: Relaxed flag parsing enabled via
AMD_EXPORTER_RELAXED_FLAGS_PARSING
Version : release-v1.4.1
BuildDate: 2025-12-18T01:03:04+0000
GitCommit: 355f71bb
Deployment: k8s deployment
[root@default-metrics-exporter-w9bhz ~]# metricsclient
ID         UUID                                     Health
Associated Workload
------------------------------------------------
0          a8ff74a1-0000-1000-807e-843c9b9a1d73     healthy    [pod :
pytorch-resnet50-cifar100, namespace : default, container:
pytorch-resnet50-cifar100]
1          bcff74a1-0000-1000-80b7-cce06393046e     healthy    []
2          15ff74a1-0000-1000-80ad-f1c8e66d53a4     healthy    []
3          f6ff74a1-0000-1000-80fb-627cf64d0590     healthy    []
4          81ff74a1-0000-1000-803d-372b45242572     healthy    []
5          05ff74a1-0000-1000-8052-f1532443045d     healthy    []
6          1dff74a1-0000-1000-80b2-8016841bb300     healthy    []
7          caff74a1-0000-1000-8013-1f3ca75ad4d6     healthy    []
------------------------------------------------
[root@default-metrics-exporter-w9bhz ~]#

```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
