### PR TITLE
Add mock AFID generation infra customer and internal testing (#1042)

### DIFF
--- a/docker/Dockerfile.exporter-mock-release
+++ b/docker/Dockerfile.exporter-mock-release
@@ -6,7 +6,7 @@ LABEL maintainer="AMD Inc"
 LABEL OS="ubuntu:22.04"
 
 RUN apt update && \
-   apt install -y sudo findutils procps file tar jq iproute2 ethtool libatomic1 && \
+   apt install -y sudo findutils procps file tar jq iproute2 ethtool libatomic1 jq vim curl && \
    apt clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/amd/bin/:/opt/rocm/bin/:/opt/nic/bin:/opt/nic/sbin

--- a/docs/configuration/configmap.md
+++ b/docs/configuration/configmap.md
@@ -15,7 +15,7 @@ When deploying AMD Device Metrics Exporter on Kubernetes, a `ConfigMap` is deplo
   - `MetricsFieldPrefix`: Add prefix string for all the fields exporter. [Premetheus Metric Label formatted](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels) string prefix will be accepted, on any invalid prefix will default to empty prefix to allow exporting of the fields.
   - `HealthService` : Health Service configurations for the exproter.
     - `Enable` : false to disable, otherwise enabled by default
-  - `LoggerConfig`: Logger configurations for the exporter.
+  - `Logging`: Logger configurations for the exporter.
     - `Level`: Log level for the exporter. Supported levels are `DEBUG`, `INFO`, `WARN`, `ERROR`. Default is `INFO`.
     - `MaxSizeMB`: Maximum size in megabytes of the log file before it gets rotated. Default is `10` MB.
     - `MaxBackups`: Maximum number of old log files to retain. Default is `3`.

--- a/example/config.json
+++ b/example/config.json
@@ -5,7 +5,7 @@
       "HealthService": {
           "Enable" : true
       },
-      "LoggerConfig": {
+      "Logging": {
           "Level": "info",
           "MaxFileSizeMB": 10,
           "MaxBackups": 3,

--- a/example/configmap.yaml
+++ b/example/configmap.yaml
@@ -12,7 +12,7 @@ data:
           "HealthService": {
              "Enable" : true
           },
-          "LoggerConfig": {
+          "Logging": {
             "Level": "info",
             "MaxFileSizeMB": 10,
             "MaxBackups": 3,

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,133 @@
+## internal testing tool usage and notes
+
+exporter is packed with `metricsclient` for debugging and testing some of
+the workflows with mocking support
+
+```
+$ metricsclient -h
+Usage of metricsclient:
+  -ecc-file-path string
+        json ecc err file
+  -get
+        send get req
+  -id string
+        send gpu id (default "1")
+  -json
+        output in json format
+  -label
+        get k8s node label
+  -socket string
+        metrics grpc socket path (default
+        "/sockets/amdgpu_device_metrics_exporter_grpc.socket")
+
+```
+1. Show GPU Health
+
+```
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]# metricsclient
+ID      Health  Associated Workload
+------------------------------------------------
+0       healthy []
+------------------------------------------------
+```
+
+2. Inject Mock ECC Error
+   To simulate ecc error create a json file of the below format with gpu id, the
+   fields set to ecc fields and counts to respective fields to be updated and issue the below command. 
+   This will print the previous reported health status of the exporter and set of counters mocked
+```
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]# cat ecc.json
+{
+        "ID": "0",
+        "Fields": [
+                "GPU_ECC_UNCORRECT_SEM",
+                "GPU_ECC_UNCORRECT_FUSE"
+        ],
+        "Counts" : [
+                1, 2
+        ]
+}
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]#
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]# metricsclient -ecc-file-path ecc.json
+ID      Health  Associated Workload
+------------------------------------------------
+0       healthy []
+------------------------------------------------
+{"ID":"0","Fields":["GPU_ECC_UNCORRECT_SEM","GPU_ECC_UNCORRECT_FUSE"]}
+```
+3. Remove ECC Mock Error
+   To remove mock fields set the respective field count values to 0 on the json file
+```
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]# cat ecc_delete.json
+{
+        "ID": "0",
+        "Fields": [
+                "GPU_ECC_UNCORRECT_SEM",
+                "GPU_ECC_UNCORRECT_FUSE"
+        ],
+        "Counts" : [
+                0, 0
+        ]
+}
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]# metricsclient -ecc-file-path ecc_delete.json
+ID      Health  Associated Workload
+------------------------------------------------
+0       unhealthy       []
+------------------------------------------------
+{"ID":"0","Fields":["GPU_ECC_UNCORRECT_SEM","GPU_ECC_UNCORRECT_FUSE"]}
+```
+
+4. Setup Mock In-Band RAS Error List
+   To setup a mock in-band RAS error list file, use the `-setup-mock-inbandras` flag. This will automatically create a `/mockdata/inband-ras/error_list` file with GPU UUIDs from the system.
+
+```bash
+[root@e2e-test-k8s-amdgpu-metrics-exporter-n8lvh ~]# metricsclient -setup-mock-inbandras
+Successfully created mock inband RAS error_list at /mockdata/inband-ras/error_list
+Added 2 GPU(s) to the mock error list
+```
+
+   The generated file will have the following JSON format with GPU UUID and AFId (AMD Feild ID) fields:
+
+```json
+{
+  "cper": [
+    {
+      "gpu": "51ff74a1-0000-1000-802e-2769a3f6a69e",
+      "afid": []
+    },
+    {
+      "gpu": "61ff74a1-0000-1000-802e-2769a3f6a69e",
+      "afid": []
+    }
+  ]
+}
+```
+
+   You can manually edit this file to add specific AFId values (array of uint64) to simulate CPER (Common Platform Error Record) entries for testing in-band RAS error handling. The `afid` field accepts array of AMD Field ID associated with the GPU errors.
+
+   Example with AFId values:
+
+```json
+{
+  "cper": [
+    {
+      "gpu": "51ff74a1-0000-1000-802e-2769a3f6a69e",
+      "afid": [55]
+    },
+    {
+      "gpu": "61ff74a1-0000-1000-802e-2769a3f6a69e",
+      "afid": [65]
+    }
+  ]
+}
+```
+
+```bash
+curl http://localhost:5000/metrics | grep -i afid
+gpu_afid_errors{afid_index="0", ... gpu_uuid="51ff74a1-0000-1000-802e-2769a3f6a69e"} 55
+gpu_afid_errors{afid_index="0", ... gpu_uuid="61ff74a1-0000-1000-802e-2769a3f6a69e"} 65
+```
+
+5. Remove Mock In-Band RAS Error List
+   To remove the mock in-band RAS delete the `rm -rf /mockdata` directory
+

--- a/pkg/amdgpu/gpuagent/gpuagent.go
+++ b/pkg/amdgpu/gpuagent/gpuagent.go
@@ -310,14 +310,14 @@ func (ga *GPUAgentClient) StartMonitor() {
 					logger.Log.Printf("gpuagent connection failed %v", err)
 					continue
 				}
+			}
 
-				if ga.enableGPUMonitoring {
-					if err := ga.processHealthValidation(); err != nil {
-						logger.Log.Printf("gpuagent health validation failed %v", err)
-					}
-					if err := ga.sendNodeLabelUpdate(); err != nil {
-						logger.Log.Printf("gpuagent failed to send node label update %v", err)
-					}
+			if ga.enableGPUMonitoring {
+				if err := ga.processHealthValidation(); err != nil {
+					logger.Log.Printf("gpuagent health validation failed %v", err)
+				}
+				if err := ga.sendNodeLabelUpdate(); err != nil {
+					logger.Log.Printf("gpuagent failed to send node label update %v", err)
 				}
 			}
 		}
@@ -332,6 +332,7 @@ func (ga *GPUAgentClient) processHealthValidation() error {
 		}
 		err := client.processHealthValidation()
 		if err != nil {
+			logger.Debugf("gpuagent client %v health validation failed %v", client.GetDeviceType(), err)
 			return err
 		}
 	}

--- a/pkg/amdgpu/gpuagent/gpuagent_gpu.go
+++ b/pkg/amdgpu/gpuagent/gpuagent_gpu.go
@@ -338,10 +338,7 @@ func (ga *GPUAgentGPUClient) cacheCperRead() (*amdgpu.GPUCPERGetResponse, error)
 	}
 
 	// Perform query and update cache
-	ctx, cancel := context.WithTimeout(ga.GetContext(), queryTimeout)
-	defer cancel()
-
-	res, err := ga.gpuclient.GPUCPERGet(ctx, &amdgpu.GPUCPERGetRequest{})
+	res, err := ga.getGPUCPER("")
 	ga.gCache.lastCperTimestamp = time.Now()
 	if err == nil {
 		ga.gCache.lastCperResponse = res
@@ -453,7 +450,7 @@ func (ga *GPUAgentGPUClient) getEvents(severity amdgpu.EventSeverity) (*amdgpu.E
 }
 
 func (ga *GPUAgentGPUClient) getGPUCPER(severity string) (*amdgpu.GPUCPERGetResponse, error) {
-	if utils.IsSimEnabled() {
+	if utils.IsMockCperEnabled() {
 		return utils.GetCperRecords()
 	}
 	ctx, cancel := context.WithTimeout(ga.GetContext(), queryTimeout)

--- a/pkg/exporter/utils/mock_utils.go
+++ b/pkg/exporter/utils/mock_utils.go
@@ -23,11 +23,26 @@ import (
 	"time"
 
 	"github.com/ROCm/device-metrics-exporter/pkg/amdgpu/gen/amdgpu"
+	"github.com/ROCm/device-metrics-exporter/pkg/exporter/logger"
+	"github.com/google/uuid"
 )
 
 var (
 	mockInbandErrorFilePath = "/mockdata/inband-ras/error_list"
 )
+
+type MockCPEREntry struct {
+	GPU  string   `json:"gpu"`
+	AFId []uint64 `json:"afid"`
+}
+type MockInbandError struct {
+	CPER []MockCPEREntry `json:"cper"`
+}
+
+func IsMockCperEnabled() bool {
+	_, err := os.Stat(mockInbandErrorFilePath)
+	return !os.IsNotExist(err)
+}
 
 // generateMockCPEREntry creates a new CPEREntry with dummy data for testing
 func generateMockCPEREntry(afid uint64) *amdgpu.CPEREntry {
@@ -42,14 +57,20 @@ func generateMockCPEREntry(afid uint64) *amdgpu.CPEREntry {
 	}
 }
 
-func getMockCPERRecords(afids []int) []*amdgpu.GPUCPEREntry {
+func getMockCPERRecords(afids []int, gpuUUID ...string) []*amdgpu.GPUCPEREntry {
 	output := make([]*amdgpu.GPUCPEREntry, 0)
+	uid := []byte("MOCK-GPU-UUID")
+	if len(gpuUUID) > 0 {
+		u, _ := uuid.Parse(gpuUUID[0])
+		uid = u[:]
+	}
 	for _, afid := range afids {
 		record := &amdgpu.GPUCPEREntry{
-			GPU:       []byte("MOCK-GPU-UUID"),
+			GPU:       uid,
 			CPEREntry: make([]*amdgpu.CPEREntry, 0),
 		}
 		record.CPEREntry = append(record.CPEREntry, generateMockCPEREntry(uint64(afid)))
+		logger.Infof("Generated mock CPER record for GPU %s with AFId %d", uid, afid)
 		output = append(output, record)
 	}
 
@@ -59,12 +80,36 @@ func getMockCPERRecords(afids []int) []*amdgpu.GPUCPEREntry {
 func GetCperRecords() (*amdgpu.GPUCPERGetResponse, error) {
 	_, err := os.Stat(mockInbandErrorFilePath)
 	if os.IsNotExist(err) {
+		logger.Errorf("mock error_list file does not exist at %s", mockInbandErrorFilePath)
 		return nil, fmt.Errorf("mock error_list file does not exist")
 	}
 	data, err := os.ReadFile(mockInbandErrorFilePath)
 	if err != nil {
+		logger.Errorf("failed to read mock error_list file: %v", err)
 		return nil, fmt.Errorf("failed to read mock error_list file: %v", err)
 	}
+	// Parse the JSON data from MockCPEREntry format else revert to the previous format
+	var mockError MockInbandError
+	err = json.Unmarshal(data, &mockError)
+	if err == nil && len(mockError.CPER) > 0 {
+		// New format with GPU UUID mapping
+		cperResponse := &amdgpu.GPUCPERGetResponse{
+			ApiStatus: amdgpu.ApiStatus_API_STATUS_OK,
+			CPER:      make([]*amdgpu.GPUCPEREntry, 0),
+		}
+		for _, entry := range mockError.CPER {
+			afids := make([]int, len(entry.AFId))
+			for i, afid := range entry.AFId {
+				afids[i] = int(afid)
+			}
+			records := getMockCPERRecords(afids, entry.GPU)
+			cperResponse.CPER = append(cperResponse.CPER, records...)
+		}
+		return cperResponse, nil
+	} else {
+		logger.Infof("mock error_list file not in new format, reverting to old format , err %v", err)
+	}
+
 	var afids []int
 	err = json.Unmarshal(data, &afids)
 	if err != nil {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -290,4 +290,7 @@ func (s *E2ESuite) TearDownSuite(c *C) {
 		s.tu.LocalCommandOutput(fmt.Sprintf("docker stop %v", s.name))
 		time.Sleep(2 * time.Second)
 	}
+
+	// Print test summary table
+	printTestSummary()
 }


### PR DESCRIPTION
* Add mock AFID generation infra customer and internal testing

```bash

amd_gpu_afid_errors{afid_index="0",card_model="102-G30201-0C",card_series="Instinct MI300",card_vendor="AMD",cluster_name="amdgpu-k8s-metrics-exporter",container="",deployment_mode="unknown",driver_ve
rsion="6.16.13",gpu_compute_partition_type="spx",gpu_id="0",gpu_memory_partition_type="nps1",gpu_partition_id="0",gpu_uuid="51ff74a1-0000-1000-802e-2769a3f6a69e",hostname="asrock-126-b3-3a",job_id="",
job_partition="",job_user="",kfd_process_id="1501697",namespace="",pod="",serial_number="PCB069272-0044",severity="fatal",vbios_version="00126442"} 30
amd_gpu_health{card_model="102-G30201-0C",card_series="Instinct MI300",card_vendor="AMD",cluster_name="amdgpu-k8s-metrics-exporter",container="",deployment_mode="unknown",driver_version="6.16.13",gpu_
compute_partition_type="spx",gpu_id="0",gpu_memory_partition_type="nps1",gpu_partition_id="0",gpu_uuid="51ff74a1-0000-1000-802e-2769a3f6a69e",hostname="asrock-126-b3-3a",job_id="",job_partition="",job
_user="",kfd_process_id="1501697",namespace="",pod="",serial_number="PCB069272-0044",vbios_version="00126442"} 0

```

* add test cases for afid mock and e2e summary for each read

(cherry picked from commit a92820faa3c8922c5027c66b147cf11e50d3a7ee)

