### PR TITLE
Add affinity configuration in the helm chart for metrics exporter daemonset

### DIFF
--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -31,6 +31,7 @@ Kubernetes: `>= 1.29.0-0`
 | kubelet.podResourceAPISocketPath | string | `"/var/lib/kubelet/pod-resources"` | host path for kubelet pod-resources directory (optional)    - vanilla k8s kubelet path: /var/lib/kubelet/pod-resources    - micro k8s kubelet path: /var/snap/microk8s/common/var/lib/kubelet/pod-resources/    - default to /var/lib/kubelet/pod-resources |
 | monitor | object | `{"resources":{"gpu":true,"nic":false}}` | monitoring configuration |
 | monitor.resources | object | `{"gpu":true,"nic":false}` | Enable or disable specific resource monitoring components. |
+| affinity | object | `{}` | Add node affinity for the daemonset of metrics exporter |
 | nodeSelector | object | `{}` | Add node selector for the daemonset of metrics exporter |
 | platform | string | `"k8s"` | Specify the platform to deploy the metrics exporter, k8s or openshift |
 | podAnnotations | object | `{}` | Add annotations to the pods |

--- a/helm-charts/templates/daemonsets.yaml
+++ b/helm-charts/templates/daemonsets.yaml
@@ -25,6 +25,10 @@ spec:
       {{- else }}
       serviceAccountName: amd-device-metrics-exporter
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -1,5 +1,7 @@
 # -- Specify the platform to deploy the metrics exporter, k8s or openshift
 platform: k8s
+# -- Add node affinity for the daemonset of metrics exporter
+affinity: {}
 # -- Add node selector for the daemonset of metrics exporter
 nodeSelector: {}
 # -- Add tolerations for deploying metrics exporter on tainted nodes


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We want to be able to specify affinity in the values file of the helm chart. This will help us streamline some of our cluster operations. For example: we don't want to hardcode a label using nodeSelector and rather use the Exists operator in affinity to check for the existence of a label on GPU nodes, so that the daemonset gets scheduled on only those nodes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
