### PR TITLE
[Build] Upgrade test runner to use ROCm 7.2

### DIFF
--- a/docker/testrunner/Dockerfile
+++ b/docker/testrunner/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 LABEL maintainer="AMD Inc"
 LABEL OS="registry.access.redhat.com/ubi9/ubi:9.6"
 
-ARG ROCM_VERSION=7.1.1
+ARG ROCM_VERSION=7.2
 ARG RADEON_REPO_URL=https://repo.radeon.com
 
 # EPEL repo is required to install yaml-cpp, a dependency of rocm-validation-suite package


### PR DESCRIPTION
## Motivation

Upgrade test runner to use ROCm 7.2 libs, the RVS version will be upgraded alongside with ROCm upgrade.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

```
+=====================================================================+
|                 ROCm Validation Suite (RVS) Summary                 |
+=====================================================================+
|                           System Overview                           |
+---------------------------------------------------------------------+
| Operating System                 | Red Hat Enterprise Linux 9.7     |
| RVS version                      | 1.3.0                            |
| ROCm version                     | N/A                              |
| amdgpu version                   | N/A                              |
| GPUs                             | 1                                |
+---------------------------------------------------------------------+
| GPU Name - GPU ID                | AMD Instinct MI210 - 35824       |
| ID - Node ID - BDF               | 0 - 2 - 0000:cc:00.0             |
+=====================================================================+
| Action Name                      | Module         | Result          |
+=====================================================================+
| gpustress-120000-bf16-false      | GST            | PASS            |
| gpustress-30000-dgemm-false      | GST            | PASS            |
| gst-8096-150000-fp16             | GST            | PASS            |
| gst-160Tflops-8K8K8K-rand-i8     | GST            | PASS            |
+---------------------------------------------------------------------+
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
