### PR TITLE
k8s is not mandatory for gpu metric collection; Fix for panic at process start.

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -278,13 +278,12 @@ func (e *Exporter) GetK8sApiClient() *k8sclient.K8sClient {
 func (e *Exporter) startWatchers() {
 	if e.k8sApiClient == nil {
 		logger.Log.Printf("k8s client is not initialized, skipping watchers")
-		return
-	}
-
-	if err := e.k8sApiClient.Watch(); err != nil {
-		logger.Log.Printf("failed to start k8s watchers: %v", err)
 	} else {
-		logger.Log.Printf("k8s watchers started successfully")
+		if err := e.k8sApiClient.Watch(); err != nil {
+			logger.Log.Printf("failed to start k8s watchers: %v", err)
+		} else {
+			logger.Log.Printf("k8s watchers started successfully")
+		}
 	}
 	if gpuclient == nil {
 		logger.Log.Fatalf("gpuclient is not initialized, skipping gpu watchers")

--- a/pkg/exporter/svc/svc_handler.go
+++ b/pkg/exporter/svc/svc_handler.go
@@ -83,16 +83,31 @@ func InitSvcs(mh *metricsutil.MetricsHandler, opts ...SvcHandlerOption) *SvcHand
 	for _, o := range opts {
 		o(svcHandler)
 	}
+
+	// Initialize GPU and NIC health services if monitoring is enabled
+	if svcHandler.enableGPUMonitoring {
+		svcHandler.gpuHealthSvc = gpumetricsserver.NewMetricsServer(svcHandler.enableDebugAPI)
+	}
+	if svcHandler.enableNICMonitoring {
+		svcHandler.nicHealthSvc = nicmetricsserver.NewMetricsServer(svcHandler.enableDebugAPI)
+	}
+
 	return svcHandler
 }
 
 // RegisterGPUHealthClient registers a GPU health client with the GPU metrics service.
 func (s *SvcHandler) RegisterGPUHealthClient(client gpumetricsserver.HealthInterface) error {
+	if s.gpuHealthSvc == nil {
+		return fmt.Errorf("GPU health service is not initialized")
+	}
 	return s.gpuHealthSvc.RegisterHealthClient(client)
 }
 
 // RegisterNICHealthClient registers a NIC health client with the NIC metrics service.
 func (s *SvcHandler) RegisterNICHealthClient(client nicmetricsserver.HealthInterface) error {
+	if s.nicHealthSvc == nil {
+		return fmt.Errorf("NIC health service is not initialized")
+	}
 	return s.nicHealthSvc.RegisterHealthClient(client)
 }
 


### PR DESCRIPTION
## Motivation

If the container is run in a non-k8s env the gpu metrics collection was also disabled. We would like to get metrics in non-k8s env also.

The code seems to have bug and panics at startup.
```

2026/02/13 06:37:09 main.go:104: BuildDate: 2026-02-13T06:23:40+0000
2026/02/13 06:37:09 main.go:105: GitCommit: 07ab8acf
.....
2026/02/13 06:37:09 gpuagent.go:436: gpuagent client closing
2026/02/13 06:37:09 gpuagent.go:448: gpuagent slurm scheduler closing
2026/02/13 06:37:09 main.go:71: panic occured: runtime error: invalid memory address or nil pointer dereference
```

## Technical Details

even if k8s is not enabled, continue with gpu metric collection.

Initialize the data-structures at startup. 
Added 2 nil-checks, just in case.

## Test Plan

Run the code and it should not crash.

## Test Result

After the fix, the code does not crash on startup.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
