### PR TITLE
Fix for race condition when multiple clients are fetching metrics simultaneously

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -46,12 +47,13 @@ import (
 )
 
 var (
-	mh                 *metricsutil.MetricsHandler
-	gpuclient          *gpuagent.GPUAgentClient
-	nicAgent           *nicagent.NICAgentClient
-	runConf            *config.ConfigHandler
-	debounceDuration   = 3 * time.Second // debounce duration for file watcher
-	defaultBindAddress = "0.0.0.0"
+	mh                     *metricsutil.MetricsHandler
+	gpuclient              *gpuagent.GPUAgentClient
+	nicAgent               *nicagent.NICAgentClient
+	runConf                *config.ConfigHandler
+	debounceDuration       = 3 * time.Second // debounce duration for file watcher
+	defaultBindAddress     = "0.0.0.0"
+	prometheusMiddlewareMu sync.Mutex
 )
 
 // ExporterOption set desired option
@@ -75,12 +77,20 @@ type Exporter struct {
 // get the info from gpu agent and update the current metrics registery
 func prometheusMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
 		url := r.URL.String()
 		if strings.Contains(strings.ToLower(url), globals.MetricsHandlerPrefix) {
 			// pull metrics only for metrics handler
+
+			// Since UpdateMetrics() is clearing metrics, we hold the lock such that no
+			// other goroutine will update/read the metrics
+			prometheusMiddlewareMu.Lock()
 			_ = mh.UpdateMetrics()
+			next.ServeHTTP(w, r)
+			prometheusMiddlewareMu.Unlock()
+		} else {
+			next.ServeHTTP(w, r)
 		}
-		next.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
## Motivation
When multiple clients are fetching metrics simultaneously, sometimes fewer metrics are returned in the response.

## Technical Details
When one goroutine is doing read, another one is doing reset(). So the first one gets smaller number of metrics.
Since the prometheus supports transactional gather, we dont need reset().

## Test Plan
One one window, did:
```
while :; do x=$(curl -q http://localhost:5000/metrics | wc -l); date; echo $x; sleep 1; done
```

In another window, did:
```
while :; do x=$(curl -s http://localhost:5000/metrics | tee /tmp/x1 | wc -l ); if [[ "$x" != "9755" ]] ; then echo "unexpected $x"; break; fi; date; done
```

## Test Result
Before the fix, the second window would stop within 5 iterations.
After the fix, it ran successfully for 50+ iterations.

## Submission Checklist
- [/] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Notes
1. Same fix may be needed in other branches too.
2. There may be some behavior changes if metrics are indeed expected to be reset between iterations. If this is really the case, then a global-lock would be solution (at the cost of much slower responses).