### PR TITLE
- Remove the "viewing documentation from a development branch" announ…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,6 @@ html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "instinct",
     "repository_url": "https://github.com/rocm/device-metrics-exporter",
-    # Add any additional theme options here
-    "announcement": (
-        "You're viewing documentation from a development branch. "
-        "Please switch to the release branch for the officially released documentation."
-    ),
     "show_navbar_depth": 0,
 }
 


### PR DESCRIPTION
 announcement from `docs/conf.py` since v1.5.0 is the released branch.

- [x] Verify Sphinx docs build for v1.5.0 no longer renders the dev-branch announcement banner.

