### PR TITLE
Update helm-chert to add priorityClassName value

### DIFF
--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -35,6 +35,7 @@ Kubernetes: `>= 1.29.0-0`
 | nodeSelector | object | `{}` | Add node selector for the daemonset of metrics exporter |
 | platform | string | `"k8s"` | Specify the platform to deploy the metrics exporter, k8s or openshift |
 | podAnnotations | object | `{}` | Add annotations to the pods |
+| priorityClassName | string | `""` | Set priorityClassName for the metrics exporter pods (optional) |
 | resources | object | `{"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"500m","memory":"512M"}}` | options for the metrics exporter container - default values are set if not specified |
 | resources.limits | object | `{"cpu":"2","memory":"4Gi"}` | Resource limits and requests for the metrics exporter container |
 | resources.limits.cpu | string | `"2"` | CPU limit for the metrics exporter container |

--- a/helm-charts/templates/daemonsets.yaml
+++ b/helm-charts/templates/daemonsets.yaml
@@ -45,6 +45,9 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       initContainers:
       - command:
         - sh

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -6,6 +6,8 @@ affinity: {}
 nodeSelector: {}
 # -- Add tolerations for deploying metrics exporter on tainted nodes
 tolerations: []
+# -- Set priorityClassName for the metrics exporter pods (optional)
+priorityClassName: ""
 # -- Add annotations to the pods
 podAnnotations: {}
 # -- DaemonSet upgrade policy configuration


### PR DESCRIPTION
## Motivation

Add the optional ability to provide a priorityClassName to the DaemonSet.

This is useful for setting it to `system-node-critical`, so it doesn't get evicted before other workloads.

## Technical Details

Updated the DaemonSet template, default values.yaml, and readme.

## Test Plan

When supplied:
```
$ helm template ./helm-charts --set priorityClassName=system-node-critical 2>&1 | grep -A1 -B1 priorityClassName
      serviceAccountName: amdgpu-metrics-exporter
      priorityClassName: system-node-critical
      initContainers:
```

When not supplied:
```
$ helm template ./helm-charts 2>&1 | grep -c priorityClassName
0
```

## Test Result

Tests passed. See above.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Those guidelines say to use `develop`, but there's no such branch here and `staging` is old. So I based off `main` for this PR. If this is correct, consider adding CONTRIBUTING.md to this repo, instead of just using the org one.