### PR TITLE
docs: update K8s version range to 1.35 and chart version to v1.5.0 (#…

### DIFF
--- a/docs/installation/deb-package.rst
+++ b/docs/installation/deb-package.rst
@@ -108,13 +108,13 @@ Step 3: Install the APT Prerequisites for Metrics Exporter
 
          .. code-block:: bash
 
-            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.4.0 jammy main
+            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.5.0 jammy main
 
       .. tab-item:: ubuntu 24.04
 
          .. code-block:: bash
 
-            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.4.0 noble main
+            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.5.0 noble main
 
 
 3. Update the package list again:

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -40,7 +40,7 @@ chmod 700 get_helm.sh
 helm repo add exporter https://rocm.github.io/device-metrics-exporter
 helm repo update
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.4.1 \
+  --version v1.5.0 \
   --namespace kube-amd-gpu \
   --create-namespace
 ```
@@ -65,7 +65,7 @@ Override individual values on the command line using `--set key=value`:
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.4.1 \
+  --version v1.5.0 \
   --namespace kube-amd-gpu \
   --create-namespace \
   --set serviceMonitor.enabled=true \
@@ -77,7 +77,7 @@ helm install exporter exporter/device-metrics-exporter-charts \
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.4.1 \
+  --version v1.5.0 \
   --namespace kube-amd-gpu \
   --create-namespace \
   --set tolerations[0].key=example.com/foo \
@@ -91,7 +91,7 @@ For more extensive customization, download and modify the default values.yaml:
 
 ```bash
 # Download the default values.yaml for GPU monitoring
-helm show values exporter/device-metrics-exporter-charts --version v1.4.1 > gpu-values.yaml
+helm show values exporter/device-metrics-exporter-charts --version v1.5.0 > gpu-values.yaml
 ```
 
 Edit `gpu-values.yaml` as needed (example below), then install using the custom file:
@@ -105,7 +105,7 @@ tolerations:
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.4.1 \
+  --version v1.5.0 \
   --namespace kube-amd-gpu \
   --create-namespace \
   -f gpu-values.yaml
@@ -125,7 +125,7 @@ Use `--dry-run` with helm install to simulate the installation without applying 
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.4.1 \
+  --version v1.5.0 \
   --namespace kube-amd-gpu \
   --create-namespace \
   --dry-run \


### PR DESCRIPTION
…1329)

- Update Kubernetes version range from "v1.29.0 or later"
- Fix stale v1.4.1 helm chart version references → v1.5.0 in kubernetes-helm.md installation examples

CP of https://github.com/pensando/device-metrics-exporter/pull/1329

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
