### PR TITLE
Typo in metrics HELP text

### DIFF
--- a/pkg/amdgpu/gpuagent/gpuagent_gpu_metrics.go
+++ b/pkg/amdgpu/gpuagent/gpuagent_gpu_metrics.go
@@ -817,7 +817,7 @@ func (ga *GPUAgentGPUClient) initPrometheusMetrics() {
 			labels),
 		gpuVCNActivity: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "gpu_vcn_activity",
-			Help: "List of Video Core Next (VCN) encoe/decode usage in percentage",
+			Help: "List of Video Core Next (VCN) encode/decode usage in percentage",
 		},
 			append([]string{"vcn_index"}, labels...)),
 		gpuJPEGActivity: *prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
## Motivation

Reduce typing mistakes

## Technical Details

Fixed Typo in `HELP amd_gpu_vcn_activity List of Video Core Next (VCN) encoe/decode usage in percentage`

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
