### PR TITLE
chore(libgimsmi): pin GIM SMI dependency to 8.7.0.K

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "libgimsmi"]
 	path = libgimsmi
 	url = git@github.com:amd/MxGPU-Virtualization.git
-	branch = mainline
+	branch = release/8.7.0.K-rc

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ AMDSMI_REPO   ?= https://github.com/ROCm/rocm-systems.git
 AMDSMI_BRANCH ?= therock-7.13
 AMDSMI_COMMIT ?= 79e85e1468f96a867108043c953e9547c13b4c5e
 AMDSMI_SUBDIR ?= projects/amdsmi
-GIMSMI_BRANCH ?= mainline
-GIMSMI_COMMIT ?= mainline/8.7.0.K
+GIMSMI_BRANCH ?= release/8.7.0.K-rc
+GIMSMI_COMMIT ?= 8.7.0.K
 GPUAGENT_BRANCH ?= main
 GPUAGENT_COMMIT ?= 9645999
 


### PR DESCRIPTION
Align the libgimsmi submodule (amd/MxGPU-Virtualization) with the GIM 8.7 release DME is on, and pin to a real, resolvable release ref instead of the prior inconsistent state.

Before this change the pin was internally inconsistent: the submodule gitlink sat at mainline/8.3.0.K while the Makefile referenced mainline/8.7.0.K, a tag that no longer exists upstream (the real tag is 8.7.0.K, no mainline/ prefix).

- libgimsmi submodule gitlink: mainline/8.3.0.K (1d4d538) -> 8.7.0.K (a5faf31).
- .gitmodules tracking branch: mainline -> release/8.7.0.K-rc.
- Makefile: GIMSMI_BRANCH -> release/8.7.0.K-rc, GIMSMI_COMMIT -> 8.7.0.K.

DME-only change; gpuagent is updated separately.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
