### PR TITLE
fix(testrunner): fix docker-test-runner base image variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ HELM_EXPORTER_IMAGE_TAG ?= $(PROJECT_VERSION)
 # Test runner container environment
 TESTRUNNER_IMAGE_TAG ?= latest
 TESTRUNNER_IMAGE_NAME ?= test-runner
-TEST_RUNNER_RHEL_BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:9.5
+TESTRUNNER_RHEL_BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi:9.6
 
 # External repo builders
 GPUAGENT_BASE_IMAGE ?= ubuntu:22.04
@@ -59,7 +59,7 @@ export TESTRUNNER_IMAGE_NAME
 export TESTRUNNER_IMAGE_TAG
 
 # exporter base container images
-export TEST_RUNNER_RHEL_BASE_IMAGE
+export TESTRUNNER_RHEL_BASE_IMAGE
 export RHEL_BASE_MIN_IMAGE
 export AZURE_BASE_IMAGE
 


### PR DESCRIPTION
## Summary
- `make docker-test-runner` was broken: the root `Makefile` exported `TEST_RUNNER_RHEL_BASE_IMAGE` while `docker/testrunner/Makefile` referenced `TESTRUNNER_RHEL_BASE_IMAGE`, so `docker build` received an empty `BASE_IMAGE`.
- The testrunner `Dockerfile` uses `dnf` and `dnf config-manager`, which `ubi9/ubi-minimal` does not ship (it only has `microdnf`), so even with the var fixed the minimal base would fail with `dnf: command not found`.

## Fix
- Rename the variable to `TESTRUNNER_RHEL_BASE_IMAGE` so both Makefiles agree.
- Set it to `registry.access.redhat.com/ubi9/ubi:9.6`, matching the Dockerfile's own `ARG BASE_IMAGE` default, which provides `dnf`.

## Test plan
- [x] `make docker-test-runner` resolves `ubi9/ubi:9.6` and proceeds through the `dnf` install steps (no `dnf: command not found`, no empty `BASE_IMAGE`)

Note: same fix as the release-v1.5.0 PR (#524).

🤖 Generated with [Claude Code](https://claude.com/claude-code)