### PR TITLE
ci: add weekly build workflow with commit-check job

### DIFF
--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,0 +1,92 @@
+name: Weekly Build
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at midnight UTC
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-build
+  cancel-in-progress: false
+
+jobs:
+  check-commits:
+    name: Check for new commits
+    runs-on: ubuntu-24.04
+    outputs:
+      has_new_commits: ${{ steps.check.outputs.has_new_commits }}
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Check for new commits since last successful run
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Always build on manual trigger
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('has_new_commits', 'true');
+              return;
+            }
+
+            // Get the last successful run of this workflow
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'weekly-build.yml',
+              status: 'success',
+              per_page: 1,
+            });
+
+            if (runs.data.total_count === 0) {
+              // No prior successful run — always build
+              core.setOutput('has_new_commits', 'true');
+              return;
+            }
+
+            const lastRunDate = runs.data.workflow_runs[0].run_started_at;
+
+            // Check for commits on the default branch since the last successful run
+            const commits = await github.rest.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              since: lastRunDate,
+              per_page: 1,
+            });
+
+            const hasNewCommits = commits.data.length > 0;
+            core.setOutput('has_new_commits', hasNewCommits.toString());
+            console.log(`Last successful run: ${lastRunDate}`);
+            console.log(`New commits found: ${hasNewCommits}`);
+
+  build:
+    name: Build
+    needs: check-commits
+    if: needs.check-commits.outputs.has_new_commits == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build dev container
+        run: make build-dev-container
+
+      - name: Build inside dev container
+        run: |
+          docker run --rm --privileged \
+            -e "GIT_COMMIT=$(git rev-list -1 HEAD --abbrev-commit)" \
+            -e "BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z)" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "${{ github.workspace }}:/usr/src/github.com/ROCm/device-metrics-exporter" \
+            -w /usr/src/github.com/ROCm/device-metrics-exporter \
+            docker.io/rocm/device-metrics-exporter-build:v1.10 \
+            bash -c "source ~/.bashrc && \
+              git config --global --add safe.directory /usr/src/github.com/ROCm/device-metrics-exporter && \
+              make gen amdexporter amdtestrunner && \
+              make docker TOP_DIR=/usr/src/github.com/ROCm/device-metrics-exporter"

--- a/tools/base-image/entrypoint.sh
+++ b/tools/base-image/entrypoint.sh
@@ -10,7 +10,8 @@ term() {
     wait
 }
 
-PATH=/usr/local/go/bin:$PATH
+export GOPATH="${GOPATH:-$(/usr/local/go/bin/go env GOPATH)}"
+PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 dockerd -s vfs &
 


### PR DESCRIPTION
## Motivation

Add a weekly build GitHub Actions workflow to keep the repository in a build-ready state on a regular cadence.

## Technical Details

- `.github/workflows/weekly-build.yml`: triggered every Sunday at midnight UTC and on `workflow_dispatch`. Includes a `check-commits` job that skips the build when no new commits have landed since the last successful run. The `build` job runs `make gen amdexporter amdtestrunner docker` inside the `device-metrics-exporter-build:v1.10` dev container.
- `tools/base-image/entrypoint.sh`: export `GOPATH` and prepend `$GOPATH/bin` to `PATH` so proto/codegen plugins installed via `go install` are resolvable inside the container.

## Test Plan

- Manually triggered via `workflow_dispatch` and verified the build job ran to completion.

## Test Result

- Build job passed on `ubuntu-24.04` runner.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.