### PR TITLE
ci: add per-PR build workflow with GHA layer caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI Build
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build dev container
+        uses: docker/build-push-action@v6
+        with:
+          context: tools/base-image
+          load: true
+          tags: docker.io/rocm/device-metrics-exporter-build:v1.10
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build inside dev container
+        run: |
+          docker run --rm --privileged \
+            -e "GIT_COMMIT=$(git rev-list -1 HEAD --abbrev-commit)" \
+            -e "BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z)" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "${{ github.workspace }}:/usr/src/github.com/ROCm/device-metrics-exporter" \
+            -w /usr/src/github.com/ROCm/device-metrics-exporter \
+            docker.io/rocm/device-metrics-exporter-build:v1.10 \
+            bash -c "source ~/.bashrc && \
+              git config --global --add safe.directory /usr/src/github.com/ROCm/device-metrics-exporter && \
+              make gen amdexporter amdtestrunner && \
+              make docker TOP_DIR=/usr/src/github.com/ROCm/device-metrics-exporter"


### PR DESCRIPTION
## Motivation

Currently CI builds only run on a weekly schedule. This adds a per-PR build so every pull request is validated before merge.

## Technical Details

- Adds `.github/workflows/ci.yml` that triggers on every PR to any branch
- Uses `docker/build-push-action` with `type=gha` cache so the dev container layers are reused across PR runs, keeping build times short
- The `Build inside dev container` step is identical to the existing `weekly-build.yml` — same `make gen amdexporter amdtestrunner && make docker` invocation
- Concurrent runs on the same branch cancel the previous one (`cancel-in-progress: true`)
- `weekly-build.yml` is unchanged

## Test Plan

- [ ] Open a PR and verify the `CI Build` workflow triggers
- [ ] Confirm second run on the same PR hits the GHA layer cache