### PR TITLE
ci: add per-PR unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,44 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      - name: Run unit tests
+        env:
+          LOGDIR: ${{ runner.temp }}/logs
+        run: |
+          mkdir -p "$LOGDIR"
+          go test -v -cover -coverprofile=coverage.out -mod=vendor ./pkg/...
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+          retention-days: 7

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,9 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
 
+      - name: Create test directories
+        run: sudo mkdir -p /var/run/exporter
+
       - name: Run unit tests
         env:
           LOGDIR: ${{ runner.temp }}/logs

--- a/pkg/exporter/metricsutil/init_test.go
+++ b/pkg/exporter/metricsutil/init_test.go
@@ -17,6 +17,7 @@
 package metricsutil
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -65,13 +66,13 @@ func setupTest(t *testing.T) func(t *testing.T) {
 	}
 	confFilePath = filePath
 
-	chandler = config.NewConfigHandler(confFilePath, globals.GPUAgentPort)
+	chandler = config.NewConfigHandler(confFilePath, config.GPUAgentConfig{GrpcPort: globals.GPUAgentPort})
 
 	mh, err = NewMetrics(chandler)
 	if err != nil {
 		t.Fatalf("metrics handler create failed: %s", err)
 	}
-	mh.InitConfig()
+	mh.InitConfig(context.Background())
 
 	t.Logf("setup completed")
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/unit-tests.yml` that runs `go test -v -cover -mod=vendor ./pkg/...` on every PR
- Uses `setup-go` with the version from `go.mod` directly on the runner — no dev container needed since there are no CGO dependencies in `pkg/`
- Cancels in-progress runs on the same ref to avoid wasting compute
- Uploads coverage report as an artifact (7-day retention)

## Test plan

- [x] Open a PR and verify the "Unit Tests" workflow triggers
- [x] Confirm tests pass and coverage output appears in the logs
- [ ] Push a second commit to the same PR and verify the first run is cancelled