### PR TITLE
docs(slurm): fix container tag, AMD GPU device fallback, method-aware commands

### DIFF
--- a/debian/usr/local/etc/metrics/slurm/slurm-epilog.sh
+++ b/debian/usr/local/etc/metrics/slurm/slurm-epilog.sh
@@ -36,6 +36,9 @@ mod128_array() {
 }
 AMDGPU_DEVICES=$(mod128_array "${CUDA_VISIBLE_DEVICES}")
 AMD_SLURM_GPUS=$(mod128_array "${SLURM_JOB_GPUS}")
+# CUDA_VISIBLE_DEVICES is empty on AMD hardware; fall back to SLURM_JOB_GPUS so
+# the per-GPU job tracking files are cleaned up correctly on job exit.
+[ -z "${AMDGPU_DEVICES}" ] && AMDGPU_DEVICES="${AMD_SLURM_GPUS}"
 MSG=$(
 	cat <<EOF
     {

--- a/debian/usr/local/etc/metrics/slurm/slurm-prolog.sh
+++ b/debian/usr/local/etc/metrics/slurm/slurm-prolog.sh
@@ -36,6 +36,9 @@ mod128_array() {
 }
 AMDGPU_DEVICES=$(mod128_array "${CUDA_VISIBLE_DEVICES}")
 AMD_SLURM_GPUS=$(mod128_array "${SLURM_JOB_GPUS}")
+# CUDA_VISIBLE_DEVICES is empty on AMD hardware; fall back to SLURM_JOB_GPUS so
+# job_id/job_user labels are still attached to the GPU metrics.
+[ -z "${AMDGPU_DEVICES}" ] && AMDGPU_DEVICES="${AMD_SLURM_GPUS}"
 MSG=$(
 	cat <<EOF
     {

--- a/docs/integrations/slurm-integration.md
+++ b/docs/integrations/slurm-integration.md
@@ -21,6 +21,8 @@ sudo chmod +x /etc/slurm/epilog.d/exporter-prolog.sh
 sudo chmod +x /etc/slurm/epilog.d/exporter-epilog.sh
 ```
 
+> **Note (AMD hardware):** `CUDA_VISIBLE_DEVICES` is empty on AMD GPUs, so the bundled scripts fall back to `SLURM_JOB_GPUS` (`[ -z "${AMDGPU_DEVICES}" ] && AMDGPU_DEVICES="${AMD_SLURM_GPUS}"`). Keep this fallback if you maintain your own copy, otherwise metrics are not tagged with `job_id`/`job_user`.
+
 - Configure Slurm:
 
 ```bash
@@ -67,8 +69,8 @@ docker run -d \
   --device=/dev/kfd \
   -v ./config:/etc/metrics \
   -v /var/run/exporter/:/var/run/exporter/ \
-  -p 5000:5000 --name exporter \
-  rocm/device-metrics-exporter:v1.3.1
+  -p 5000:5000 --name device-metrics-exporter \
+  rocm/device-metrics-exporter:v1.5.0
 ```
 
 ## Verification
@@ -115,7 +117,10 @@ When Slurm integration is enabled, the following job-specific labels are added t
 4. Check service status:
 
 ```bash
+# Host package (apt):
 systemctl status gpuagent.service amd-metrics-exporter.service
+# Container (Docker):
+docker ps --filter name=device-metrics-exporter
 ```
 
 ### Logs
@@ -129,7 +134,10 @@ sudo tail -f /var/log/slurm/slurmd.log
 View service logs:
 
 ```bash
+# Host package (apt):
 journalctl -u gpuagent.service -u amd-metrics-exporter.service
+# Container (Docker): logs are written to /var/log/exporter.log inside the container
+docker exec device-metrics-exporter tail -f /var/log/exporter.log
 ```
 
 ## Advanced Configuration


### PR DESCRIPTION
Documentation and prolog/epilog fixes for the Slurm integration, found while validating the runbook end-to-end on AMD MI300X hardware.

- Bump the exporter container tag from v1.3.1 to v1.5.0 to match the Docker installation guide and the latest release.
- Fall back to SLURM_JOB_GPUS when CUDA_VISIBLE_DEVICES is empty on AMD hardware in slurm-prolog.sh and slurm-epilog.sh, otherwise GPU metrics are not tagged with job_id/job_user; note this in the runbook.
- Label the troubleshooting/logs commands as host-package (systemctl/journalctl) vs container (docker), since those units only exist with the host package.

## Motivation

An end-to-end validation of the Slurm integration runbook on a 4-node MI300X cluster (Slurm 25.05, auth/slurm, 8x GPU per node) surfaced a few issues. On AMD hardware the stock prolog/epilog rely on `CUDA_VISIBLE_DEVICES`, which is empty, so GPU metrics were never tagged with `job_id`/`job_user`. The runbook also pinned an old container tag and mixed host-only troubleshooting commands into the Docker flow, which was confusing. This PR addresses that feedback so the runbook works as written for both deployment methods.

## Technical Details

- `debian/usr/local/etc/metrics/slurm/slurm-prolog.sh` and `slurm-epilog.sh`: `CUDA_VISIBLE_DEVICES` is empty on AMD GPUs, so fall back to `SLURM_JOB_GPUS` when deriving the GPU list:
  `[ -z "${AMDGPU_DEVICES}" ] && AMDGPU_DEVICES="${AMD_SLURM_GPUS}"`.
  Without this, no per-GPU files are written to `/var/run/exporter`, so metrics are not tagged with `job_id`/`job_user`.
- `docs/integrations/slurm-integration.md`:
  - Bump the container tag from `v1.3.1` to `v1.5.0` to match [docs/installation/docker.md](../installation/docker.md) and the latest release.
  - Annotate the troubleshooting and log commands as host-package (`systemctl`/`journalctl` for `gpuagent.service` and `amd-metrics-exporter.service`) vs container (`docker ps` / `docker logs`), since those `systemd` units only exist with the host package.
  - Add a note documenting the `SLURM_JOB_GPUS` fallback for AMD hardware.

## Test Plan

Validated on a 4-node MI300X cluster (Slurm 25.05, auth/slurm, 8x GPU per node) from a clean Slurm state, deploying the exporter via both the Docker and the apt host-package methods:

1. Install the prolog/epilog scripts; set `prologFlags=Alloc` plus `Prolog`/`Epilog` in `slurm.conf`; restart `slurmd`.
2. Submit GPU jobs and inspect the metrics endpoint:
   ```bash
   srun --gpus=1 amd-smi monitor
   curl -s http://localhost:5000/metrics | grep job_id
   ```
3. Confirm labels populate during the job and clear on job exit.
4. `bash -n` syntax check on both scripts.

## Test Result

- Both deployment methods (Docker and apt host-package) work.
- With the `SLURM_JOB_GPUS` fallback, `job_id`, `job_user`, and `job_partition` labels populate on AMD GPUs while a job runs and clear on job exit (verified via the prolog/epilog and the `/metrics` endpoint).
- `bash -n` passes on both `slurm-prolog.sh` and `slurm-epilog.sh`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
