### PR TITLE
docs: remove dev-branch announcement banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,10 +19,6 @@ html_theme_options = {
     "flavor": "instinct",
     "repository_url": "https://github.com/rocm/device-metrics-exporter",
     # Add any additional theme options here
-    "announcement": (
-        "You're viewing documentation from a development branch. "
-        "Please switch to the release branch for the officially released documentation."
-    ),
     "show_navbar_depth": 0,
 }
 


### PR DESCRIPTION
## Summary
- Removes the "You're viewing documentation from a development branch..." announcement banner from `docs/conf.py` on the `release-v1.5.1` branch, matching prior release branches (e.g. `release-v1.4.1`, `release-v1.4.2`, `release-v1.5.0`) which don't carry this banner.

## Test plan
- [x] Verified `docs/conf.py` diff removes only the `announcement` block
- [x] Confirmed other release branches lack this banner while `main` retains it