### PR TITLE
chore: update CODEOWNERS and note AMD emails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @ROCm/device-metrics-exporter
-@spraveenio @yansun1996 @rchirakk @bhatnitish
+@spraveenio @yansun1996 @rchirakk @bhatnitish @bhatturu
+# prshanmug@amd.com   Yan.Sun3@amd.com   rchirakk@amd.com   nitish.bhat@amd.com   bhatturu@amd.com
 
 # Documentation files
 docs/ @ROCm/device-metrics-exporter


### PR DESCRIPTION
## Summary
- Adds `@bhatturu` as an additional code owner
- Documents each listed member's AMD email address in a comment for reference

## Test plan
- N/A (CODEOWNERS file change only)