### PR TITLE
[CP 1541] [NO-JIRA] Branch prep: v1.5.2 version bump

### DIFF
--- a/docker/Dockerfile.exporter-release
+++ b/docker/Dockerfile.exporter-release
@@ -244,8 +244,8 @@ RUN chmod +x /home/amd/bin/metrics-exporter-ts.sh
 LABEL name="amd-device-metrics-exporter" \
     maintainer="praveenkumar.shanmugam@amd.com,nitish.bhat@amd.com,yan.sun3@amd.com,shrey.ajmera@amd.com" \
     vendor="Advanced Micro Devices, Inc." \
-    version="v1.5.1" \
-    release="v1.5.1" \
+    version="v1.5.2" \
+    release="v1.5.2" \
     ROCM_VERSION="${ROCM_VERSION}" \
     summary="AMD Device Metrics Exporter enables out-of-the-box metrics collection for AMD GPUs on Kubernetes." \
     description="AMD Device Metrics Exporter enables Prometheus-format metrics collection for AMD GPUs in HPC and AI environments. It provides detailed telemetry including temperature, utilization, memory usage, and power consumption."

--- a/docker/testrunner/Dockerfile
+++ b/docker/testrunner/Dockerfile
@@ -70,8 +70,8 @@ ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib/rvs:/opt/rocm/lib/rocm_sysdeps/l
 LABEL name="amd-device-test-runner" \
     maintainer="yan.sun3@amd.com,udaybhaskar.biluri@amd.com,shrey.ajmera@amd.com" \
     vendor="Advanced Micro Devices, Inc." \
-    version="v1.5.0" \
-    release="v1.5.0" \
+    version="v1.5.2" \
+    release="v1.5.2" \
     summary="AMD Device Test Runner performs troubleshooting and benchmarking tests on AMD GPUs across Kubernetes clusters." \
     description="AMD Device Test Runner ensures that GPUs are functioning correctly and efficiently by running a series of diagnostic tests and performance benchmarks. It helps identify issues, optimize GPU performance, and validate the readiness of GPU resources by running Rocm Validation Suite (RVS) tests."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,8 @@ external_projects = ["device-metrics-exporter"]
 external_projects_current_project = "device-metrics-exporter"
 
 project = "AMD Instinct Hub"
-version = "1.5.1"
-debian_version = "1.5.1"
+version = "1.5.2"
+debian_version = "1.5.2"
 release = version
 html_title = f"AMD Device Metrics Exporter {version}"
 author = "Advanced Micro Devices, Inc."

--- a/docs/configuration/configmap.md
+++ b/docs/configuration/configmap.md
@@ -71,7 +71,7 @@ To use a custom configuration when deploying the Metrics Exporter:
 3. Run `helm install`:
 
 ```bash
-helm install exporter https://github.com/ROCm/device-metrics-exporter/releases/download/v1.5.1/device-metrics-exporter-charts-v1.5.1.tgz -n metrics-exporter -f values.yaml --create-namespace
+helm install exporter https://github.com/ROCm/device-metrics-exporter/releases/download/v1.5.2/device-metrics-exporter-charts-v1.5.2.tgz -n metrics-exporter -f values.yaml --create-namespace
 ```
 
 Device Metrics Exporter polls for configuration changes every minute, so updates take effect without container restarts.

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -18,7 +18,7 @@ docker run -d \
   -p 5000:5000 \
   -v ./config:/etc/metrics \
   --name device-metrics-exporter \
-  rocm/device-metrics-exporter:v1.5.1
+  rocm/device-metrics-exporter:v1.5.2
 ```
 
 **_NOTE:_** `--privileged` is required. If profiler metrics (`gpu_prof_*`) are

--- a/docs/developerguide.md
+++ b/docs/developerguide.md
@@ -157,7 +157,7 @@ Deploys DME via its standalone Helm chart and verifies metrics, health, and labe
 bash test/k8s-e2e/run-e2e.sh --dme \
   --kubeconfig /path/to/kubeconfig \
   --registry rocm/device-metrics-exporter \
-  --imagetag v1.5.1
+  --imagetag v1.5.2
 ```
 
 ### Running with make (inside the build container)
@@ -167,7 +167,7 @@ From inside the `test/k8s-e2e/` directory, or via the top-level Makefile with `T
 ```bash
 # DME standalone
 make all TOP_DIR=$(pwd) KUBECONFIG=/path/to/kubeconfig \
-  DOCKER_REGISTRY=rocm EXPORTER_IMAGE_NAME=device-metrics-exporter EXPORTER_IMAGE_TAG=v1.5.1
+  DOCKER_REGISTRY=rocm EXPORTER_IMAGE_NAME=device-metrics-exporter EXPORTER_IMAGE_TAG=v1.5.2
 ```
 
 ### Running with go test directly
@@ -181,7 +181,7 @@ cd test/k8s-e2e
 go test -mod=vendor -v -failfast \
   -helmchart ../../helm-charts \
   -registry rocm/device-metrics-exporter \
-  -imagetag v1.5.1 \
+  -imagetag v1.5.2 \
   -kubeconfig /path/to/kubeconfig \
   -test.timeout 30m
 ```

--- a/docs/installation/deb-package.rst
+++ b/docs/installation/deb-package.rst
@@ -86,13 +86,13 @@ Step 3: Install the APT Prerequisites for Metrics Exporter
 
          .. code-block:: bash
 
-            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.5.1 jammy main
+            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.5.2 jammy main
 
       .. tab-item:: ubuntu 24.04
 
          .. code-block:: bash
 
-            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.5.1 noble main
+            deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/device-metrics-exporter/apt/1.5.2 noble main
 
 
 3. Update the package list again:

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -25,7 +25,7 @@ docker run -d \
   -v /sys:/sys:ro \
   -p 5000:5000 \
   --name device-metrics-exporter \
-  rocm/device-metrics-exporter:v1.5.1
+  rocm/device-metrics-exporter:v1.5.2
 ```
 
 - Confirm metrics are accessible:

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -40,7 +40,7 @@ chmod 700 get_helm.sh
 helm repo add exporter https://rocm.github.io/device-metrics-exporter
 helm repo update
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.5.1 \
+  --version v1.5.2 \
   --namespace kube-amd-gpu \
   --create-namespace
 ```
@@ -65,7 +65,7 @@ Override individual values on the command line using `--set key=value`:
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.5.1 \
+  --version v1.5.2 \
   --namespace kube-amd-gpu \
   --create-namespace \
   --set serviceMonitor.enabled=true \
@@ -77,7 +77,7 @@ helm install exporter exporter/device-metrics-exporter-charts \
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.5.1 \
+  --version v1.5.2 \
   --namespace kube-amd-gpu \
   --create-namespace \
   --set tolerations[0].key=example.com/foo \
@@ -91,7 +91,7 @@ For more extensive customization, download and modify the default values.yaml:
 
 ```bash
 # Download the default values.yaml for GPU monitoring
-helm show values exporter/device-metrics-exporter-charts --version v1.5.1 > gpu-values.yaml
+helm show values exporter/device-metrics-exporter-charts --version v1.5.2 > gpu-values.yaml
 ```
 
 Edit `gpu-values.yaml` as needed (example below), then install using the custom file:
@@ -105,7 +105,7 @@ tolerations:
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.5.1 \
+  --version v1.5.2 \
   --namespace kube-amd-gpu \
   --create-namespace \
   -f gpu-values.yaml
@@ -125,7 +125,7 @@ Use `--dry-run` with helm install to simulate the installation without applying 
 
 ```bash
 helm install exporter exporter/device-metrics-exporter-charts \
-  --version v1.5.1 \
+  --version v1.5.2 \
   --namespace kube-amd-gpu \
   --create-namespace \
   --dry-run \

--- a/docs/installation/singularity.md
+++ b/docs/installation/singularity.md
@@ -12,7 +12,7 @@ The Device Metrics Exporter container is hosted on Docker Hub at [rocm/device-me
 
   ```bash
   bootstrap: docker
-  From: rocm/device-metrics-exporter:v1.5.1
+  From: rocm/device-metrics-exporter:v1.5.2
 
   %post
       chmod +x /home/amd/tools/entrypoint.sh

--- a/docs/integrations/prometheus-grafana.md
+++ b/docs/integrations/prometheus-grafana.md
@@ -75,7 +75,7 @@ If you're using Kubernetes, you can install Prometheus and Grafana using the Pro
 
    ```bash
    helm install metrics-exporter \
-     https://github.com/ROCm/device-metrics-exporter/releases/download/v1.5.1/device-metrics-exporter-charts-v1.5.1.tgz \
+     https://github.com/ROCm/device-metrics-exporter/releases/download/v1.5.2/device-metrics-exporter-charts-v1.5.2.tgz \
      --set serviceMonitor.enabled=true \
      --set serviceMonitor.interval=15s \
      -n mynamespace --create-namespace

--- a/docs/integrations/slurm-integration.md
+++ b/docs/integrations/slurm-integration.md
@@ -70,7 +70,7 @@ docker run -d \
   -v ./config:/etc/metrics \
   -v /var/run/exporter/:/var/run/exporter/ \
   -p 5000:5000 --name device-metrics-exporter \
-  rocm/device-metrics-exporter:v1.5.0
+  rocm/device-metrics-exporter:v1.5.2
 ```
 
 ## Verification

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v1.5.2
+
+- **New Features**
+
+### Issues Fixed
+
+### Known Issues
+
 ## v1.5.1
 
 - **New Platform Support**

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - monitoring
   - prometheus
 type: application
-version: v1.5.0
-appVersion: v1.5.0
+version: v1.5.2
+appVersion: v1.5.2
 kubeVersion: ">= 1.29.0-0"
 maintainers:
   - email: prshanmug@amd.com

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -42,7 +42,7 @@ image:
   # -- repository URL for the metrics exporter image
   repository: docker.io/rocm/device-metrics-exporter
   # -- metrics exporter image tag
-  tag: v1.5.0
+  tag: v1.5.2
   # -- metrics exporter image pullPolicy
   pullPolicy: Always
   # -- metrics exporter image pullSecret name


### PR DESCRIPTION
Cherry-pick of pensando/device-metrics-exporter#1541 (fbaa6c882). Normalize GPU-track version strings to v1.5.2.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
