### PR TITLE
Update release-v1.5.2 build pins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ GIMSMI_COMMIT ?= 9.1.0.K
 # requires a full SHA (abbreviated SHAs are rejected by the remote).
 GPUAGENT_REPO ?= https://github.com/ROCm/gpu-agent.git
 GPUAGENT_BRANCH ?= main
-GPUAGENT_COMMIT ?= 22f92dc12f464f70d47ccf9ee87dadf577cf9574
+GPUAGENT_COMMIT ?= 9cee401919f8f25f7465d778fb0e4274408dc438
 
 # authoritative ROCm tarball defaults (not overridden in dev.env).
 # ROCM_VERSION must match the tarball's version string (extracts to

--- a/docker/Dockerfile.exporter-release
+++ b/docker/Dockerfile.exporter-release
@@ -15,13 +15,13 @@ FROM ${GPUAGENT_BUILDER_BASE_IMAGE} AS gpuagent-build
 
 ARG GPUAGENT_REPO=https://github.com/ROCm/gpu-agent.git
 # full 40-char SHA required for shallow fetch-by-SHA
-ARG GPUAGENT_COMMIT=22f92dc12f464f70d47ccf9ee87dadf577cf9574
+ARG GPUAGENT_COMMIT=9cee401919f8f25f7465d778fb0e4274408dc438
 # 0 = use pre-staged amdsmi from build context (default, no download)
 # 1 = re-extract amdsmi from the (~10GB) ROCm therock tarball
 ARG AMDSMI_FROM_TARBALL=0
 ARG ROCM_TARBALL_URL=
-ARG GO_VERSION=1.25.12
-ARG GO_SHA256=234828b7a89e0e303d2556310ee549fbcf253d28de937bac3da13d6294262ac1
+ARG GO_VERSION=1.25.13
+ARG GO_SHA256=39042a078ea9ceebe3ecda4a7188f0f5b96e14a071d27923ba7f40b456e85ae3
 
 # build toolchain (full ubi9 has dnf/yum) + go
 RUN dnf install -y --allowerasing \


### PR DESCRIPTION
## Motivation
This pull request updates the build configuration to use newer versions of both the `gpu-agent` dependency and the Go programming language. These changes ensure that the build process uses the latest compatible versions and corresponding checksums.

Dependency updates:

* Updated the `GPUAGENT_COMMIT` SHA in both the `Makefile` and `docker/Dockerfile.exporter-release` to point to a newer commit, ensuring the build uses the latest version of the `gpu-agent` dependency. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L134-R134) [[2]](diffhunk://#diff-3d35cc9a3362d21f70beca921f6d72c0aa326c73f0e7f62d257b417a745f5806L18-R24)

Go toolchain update:

* Updated the Go version from `1.25.12` to `1.25.13` and changed the corresponding SHA256 checksum in `docker/Dockerfile.exporter-release` to match the new version, ensuring integrity and compatibility.
