### PR TITLE
ci: add force_rebuild option and amdpsdo registry push

### DIFF
--- a/.github/workflows/rocm-build.yml
+++ b/.github/workflows/rocm-build.yml
@@ -38,7 +38,7 @@ on:
         type: boolean
         default: false
       force_rebuild:
-        description: 'Force rebuild even if already built for this SHA + tarball'
+        description: 'Force rebuild even if already built for this SHA + image tag'
         required: false
         type: boolean
         default: false
@@ -356,7 +356,7 @@ jobs:
           aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" --human-readable || true
 
       - name: Login to Docker Hub
-        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.resolve.outputs.skip_upload == 'false' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -364,7 +364,7 @@ jobs:
 
       - name: Push images to amdpsdo registry
         id: registry-push
-        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.resolve.outputs.skip_upload == 'false' }}
         env:
           IMAGE_TAG:   ${{ needs.resolve.outputs.image_tag }}
           DME_VERSION: ${{ needs.resolve.outputs.dme_version }}
@@ -405,7 +405,12 @@ jobs:
             echo "| ROCm tarball | \`${ROCM_TARBALL_URL}\` |"
             echo "| Image tag | \`${IMAGE_TAG}\` |"
             echo "| Build | ${BUILD_RESULT} |"
-            echo "| S3 upload | ${S3_RESULT:-skipped} |"
-            echo "| Registry push | ${REGISTRY_RESULT:-skipped} |"
+            if [ "${SKIP_UPLOAD}" = "true" ]; then
+              echo "| S3 upload | skipped (upload disabled) |"
+              echo "| Registry push | skipped (upload disabled) |"
+            else
+              echo "| S3 upload | ${S3_RESULT:-failure} |"
+              echo "| Registry push | ${REGISTRY_RESULT:-skipped} |"
+            fi
             echo "| S3 prefix | \`s3://${S3_BUCKET}/${S3_PREFIX}/\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rocm-build.yml
+++ b/.github/workflows/rocm-build.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      force_rebuild:
+        description: 'Force rebuild even if already built for this SHA + tarball'
+        required: false
+        type: boolean
+        default: false
 
 
 concurrency:
@@ -66,7 +71,7 @@ jobs:
       s3_prefix:        ${{ steps.resolve.outputs.s3_prefix }}
       skip_upload:      ${{ steps.resolve.outputs.skip_upload }}
       dme_version:      ${{ steps.resolve.outputs.dme_version }}
-      build_needed:    ${{ steps.dedup.outputs.cache-hit != 'true' }}
+      build_needed:    ${{ steps.dedup.outputs.cache-hit != 'true' || inputs.force_rebuild == true }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -321,6 +326,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload artifacts to S3
+        id: s3-upload
         if: ${{ needs.resolve.outputs.skip_upload == 'false' }}
         env:
           S3_PREFIX: ${{ needs.resolve.outputs.s3_prefix }}
@@ -349,6 +355,36 @@ jobs:
           echo "All artifacts uploaded to s3://${S3_BUCKET}/${S3_PREFIX}/"
           aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" --human-readable || true
 
+      - name: Login to Docker Hub
+        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Push images to amdpsdo registry
+        id: registry-push
+        if: ${{ always() && needs.resolve.outputs.skip_upload == 'false' }}
+        env:
+          IMAGE_TAG:   ${{ needs.resolve.outputs.image_tag }}
+          DME_VERSION: ${{ needs.resolve.outputs.dme_version }}
+        run: |
+          set -euo pipefail
+          PUSH_TAG="${DME_VERSION}-${IMAGE_TAG}"
+
+          docker load < "artifacts/device-metrics-exporter-${PUSH_TAG}.tar.gz"
+          docker tag "docker.io/rocm/device-metrics-exporter:${IMAGE_TAG}" \
+                     "docker.io/amdpsdo/device-metrics-exporter:${PUSH_TAG}"
+          docker push "docker.io/amdpsdo/device-metrics-exporter:${PUSH_TAG}"
+
+          docker load < "artifacts/test-runner-${PUSH_TAG}.tar.gz"
+          docker tag "docker.io/rocm/test-runner:${IMAGE_TAG}" \
+                     "docker.io/amdpsdo/test-runner:${PUSH_TAG}"
+          docker push "docker.io/amdpsdo/test-runner:${PUSH_TAG}"
+
+          echo "Pushed docker.io/amdpsdo/device-metrics-exporter:${PUSH_TAG}"
+          echo "Pushed docker.io/amdpsdo/test-runner:${PUSH_TAG}"
+
       - name: Generate build summary
         if: always()
         env:
@@ -357,6 +393,8 @@ jobs:
           S3_PREFIX:        ${{ needs.resolve.outputs.s3_prefix }}
           SKIP_UPLOAD:      ${{ needs.resolve.outputs.skip_upload }}
           BUILD_RESULT:     ${{ needs.build.result }}
+          S3_RESULT:        ${{ steps.s3-upload.outcome }}
+          REGISTRY_RESULT:  ${{ steps.registry-push.outcome }}
         run: |
           {
             echo "## DME Build — \`${IMAGE_TAG}\`"
@@ -367,6 +405,7 @@ jobs:
             echo "| ROCm tarball | \`${ROCM_TARBALL_URL}\` |"
             echo "| Image tag | \`${IMAGE_TAG}\` |"
             echo "| Build | ${BUILD_RESULT} |"
+            echo "| S3 upload | ${S3_RESULT:-skipped} |"
+            echo "| Registry push | ${REGISTRY_RESULT:-skipped} |"
             echo "| S3 prefix | \`s3://${S3_BUCKET}/${S3_PREFIX}/\` |"
-            echo "| Upload skipped | \`${SKIP_UPLOAD}\` |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add `force_rebuild` workflow_dispatch input to bypass dedup cache when needed
- Push DME + test-runner images to `docker.io/amdpsdo` after S3 upload
- Registry push runs independently of S3 (S3 failure does not skip registry push)
- Build summary reports individual outcomes for S3 and registry push

🤖 Generated with [Claude Code](https://claude.com/claude-code)