### PR TITLE
Switch theme flavor to instinct-design

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved
 # Required settings
 html_theme = "rocm_docs_theme"
 html_theme_options = {
-    "flavor": "instinct",
+    "flavor": "instinct-design",
     "use_download_button": True,
     "repository_url": "https://github.com/rocm/device-metrics-exporter",
     # Add any additional theme options here


### PR DESCRIPTION
## Summary
- Aligns this repo's docs theme with the redesign rolled out in [ROCm/instinct-docs](https://github.com/ROCm/instinct-docs) ([PR #133](https://github.com/ROCm/instinct-docs/pull/133)), switching `html_theme_options["flavor"]` from `instinct` to `instinct-design` in `docs/conf.py`.
- One-line change, no other content or structure touched.

## Context
Part of a follow-up sweep across GSID in-scope doc repos to bring them onto the same `instinct-design` flavor as instinct-docs, for visual consistency across the doc set (tracked in an internal follow-up to the instinct-docs redesign).

## Test plan
- [ ] RTD/CI docs build succeeds
- [ ] Spot-check the rendered docs pick up the instinct-design flavor as expected