### PR TITLE
ci: update nightly CDN URL to nightly.repo.amd.com

### DIFF
--- a/.github/workflows/rocm-build.yml
+++ b/.github/workflows/rocm-build.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          NIGHTLY_CDN_BASE="https://rocm.nightlies.amd.com/tarball-multi-arch"
+          NIGHTLY_CDN_BASE="https://nightly.repo.amd.com/rocm/core/tarball"
           PR_FALLBACK_URL=$(grep -m1 'ROCM_TARBALL_URL ?=' Makefile | awk '{print $NF}')
           DME_VERSION=$(grep -m1 'PROJECT_VERSION ?=' Makefile | awk '{print $NF}')
 


### PR DESCRIPTION
## Summary
- Update nightly tarball CDN base URL from `rocm.nightlies.amd.com/tarball-multi-arch` to `nightly.repo.amd.com/rocm/core/tarball`
- The old CDN has been decommissioned; nightly builds are now hosted at the new URL

## Test plan
- [ ] Verify nightly schedule trigger picks the latest tarball from the new CDN
- [ ] Verify tarball name regex still matches (e.g. `therock-dist-linux-multiarch-10.1.0a20260831.tar.gz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)